### PR TITLE
fix(labels): use gh jq for paginated label reads

### DIFF
--- a/scripts/labels-dry-run.rb
+++ b/scripts/labels-dry-run.rb
@@ -91,7 +91,7 @@ end
 
 def gh_paginated_array(path)
   stdout, stderr, status = Open3.capture3(
-    "gh", "api", path, "--paginate", "--template", "{{range .}}{{json .}}{{\"\\n\"}}{{end}}"
+    "gh", "api", path, "--paginate", "--jq", ".[]"
   )
   unless status.success?
     raise "gh api #{path} failed: #{stderr.strip.empty? ? stdout.strip : stderr.strip}"


### PR DESCRIPTION
## Summary
- replace the dry-run helper's `gh api --template` usage with `gh api --jq '.[]'`
- keeps paginated label reads as newline-delimited JSON objects
- fixes compatibility with the installed `gh` version, where the template `json` function is unavailable

## Test Plan
- `ruby -c scripts/labels-dry-run.rb`
- `scripts/labels-dry-run.rb --repo z-shell/.github --include-clean`
- `scripts/labels-dry-run.rb --repo z-shell/zi`
- `scripts/labels-dry-run.rb --repo z-shell/.github --json | ruby -rjson -e 'data=JSON.parse($stdin.read); puts "repos=#{data["repos_scanned"]} drift=#{data["repos_with_drift"]}"'`
- `scripts/labels-dry-run.rb --repo z-shell/.github --all-repos` exits 2

Follow-up for #411 and #423.
