### PR TITLE
fix(labels): support older Ruby hash iteration

### DIFF
--- a/scripts/labels-sync.rb
+++ b/scripts/labels-sync.rb
@@ -238,7 +238,7 @@ def diff_repo(owner_repo, canonical, legacy_migrations)
 
   missing = canonical.keys.reject { |name| live_by_name.key?(name) }
 
-  updates = canonical.filter_map do |name, desired|
+  updates = canonical.each_with_object([]) do |(name, desired), items|
     current = live_by_name[name]
     next unless current
 
@@ -249,13 +249,13 @@ def diff_repo(owner_repo, canonical, legacy_migrations)
     if current.fetch("description") != desired.fetch("description")
       changes["description"] = { "current" => current.fetch("description"), "desired" => desired.fetch("description") }
     end
-    changes.empty? ? nil : { "name" => name, "changes" => changes }
+    items << { "name" => name, "changes" => changes } unless changes.empty?
   end
 
-  legacy_present = legacy_migrations.filter_map do |legacy, replacement|
+  legacy_present = legacy_migrations.each_with_object([]) do |(legacy, replacement), items|
     next unless live_by_name.key?(legacy)
 
-    { "legacy" => legacy, "replacement" => replacement }
+    items << { "legacy" => legacy, "replacement" => replacement }
   end
 
   unknown = live_by_name.keys.reject do |name|


### PR DESCRIPTION
## Summary

Fixes the label sync audit script used by the `#411` label-taxonomy rollout.

On the local Ruby available in this maintainer environment, `Hash#filter_map` is unavailable, so the documented dry-run command failed before it could audit labels. This changes the two hash `filter_map` call sites to `each_with_object([])` while preserving the same output shape.

## Verification

- `ruby -c scripts/labels-sync.rb`
- `ruby -e 'require "yaml"; data=YAML.safe_load(File.read("lib/labels.yml"), aliases: false); names=data.fetch("labels").map{|l| l.fetch("name")}; abort "duplicate labels" unless names.uniq == names; puts "labels=#{names.size} legacy=#{data.fetch("legacy_migrations").size}"'`
- `scripts/labels-sync.rb --repo z-shell/.github --include-clean`
  - Read-only dry run.
  - Canonical labels: 31.
  - Legacy migrations: 30.
  - Repos scanned: 1.
  - Repos with drift: 0.
  - `z-shell/.github` clean.

## Related

Refs #411.

## Agent handoff

No handoff needed.