### PR TITLE
fix(trunk): quote runs-on input reference

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -126,7 +126,7 @@ permissions:
 jobs:
   trunk:
     name: Trunk Code Quality
-    runs-on: ${{ inputs.runs-on }}
+    runs-on: ${{ inputs['runs-on'] }}
     permissions:
       actions: read
       checks: write


### PR DESCRIPTION
## Summary
- use bracket notation for the hyphenated reusable-workflow `runs-on` input
- restore validation for callers of the organization Trunk workflow

## Evidence
New callers failed before job creation with zero jobs. The reusable workflow used `${{ inputs.runs-on }}`, while all other hyphenated inputs correctly use bracket notation.

## Verification
- YAML parse with Ruby Psych
- `git diff --check`
- scan for hyphenated `inputs.*-*` dot notation

Tracks #408.