### PR TITLE
fix(trunk): let callers own concurrency

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -1,10 +1,6 @@
 ---
 name: Trunk Code Quality
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 on:
   workflow_call:
     secrets:


### PR DESCRIPTION
## Summary
- remove top-level concurrency from the reusable Trunk workflow
- keep concurrency on each push/PR caller

## Evidence
After #434, callers resolved the repaired reusable workflow but still failed before job creation. The called workflow reused the caller's `${{ github.workflow }}-${{ github.ref }}` group with `cancel-in-progress: true`, cancelling the invoking run.

## Verification
- YAML parse with Ruby Psych
- `git diff --check`
- workspace audit confirms active callers retain concurrency

Tracks #408.