### PR TITLE
fix(trunk): remove stale sh-hook action blocking local git hooks

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -60,9 +60,3 @@ actions:
     - trunk-upgrade-available
     - trunk-cache-prune
     - trunk-announce
-    - sh-hook
-  definitions:
-    - id: sh-hook
-      triggers:
-        - git_hooks: [pre-push, pre-commit]
-      run: .github/hook.sh


### PR DESCRIPTION
## Problem

`.trunk/trunk.yaml` enables a custom `sh-hook` action that runs `.github/hook.sh` on the `pre-commit` and `pre-push` git hooks, but that script was deleted in e3fd962db. Every `git commit` / `git push` in a local clone with trunk-managed hooks fails:

```text
sh-hook: line 1: .github/hook.sh: No such file or directory
✖ Commit blocked by git hook 'sh-hook'
```

## Fix

Remove the `sh-hook` entry from both `actions.enabled` and `actions.definitions`. The deleted script only ran `trunk check --show-existing --no-progress`, which trunk's built-in `trunk-check-pre-push` / `trunk-fmt-pre-commit` actions already provide when desired (both are deliberately disabled in this config).

Closes #445

🤖 Generated with [Claude Code](https://claude.com/claude-code)