### PR TITLE
chore(labels): add performance to the canonical label set

### DIFF
--- a/lib/labels.yml
+++ b/lib/labels.yml
@@ -76,6 +76,9 @@ labels:
   - name: security
     color: ee0701
     description: Security-sensitive issue or hardening work.
+  - name: performance
+    color: "006b75"
+    description: Performance-sensitive work or a measured regression in speed or memory.
   - name: breaking-change
     color: d93f0b
     description: Breaks backward compatibility or changes a public contract.
@@ -147,6 +150,7 @@ legacy_migrations:
   help-wanted: help wanted
   breaking-change 💥: breaking-change
   security 🛡️: security
+  performance 🚀: performance
   invalid ⚠️: invalid
 
 sync_policy:

--- a/lib/labels.yml
+++ b/lib/labels.yml
@@ -22,19 +22,19 @@ labels:
     color: 0e8a16
     description: A request for new behavior or capability.
   - name: type:docs
-    color: '0052cc'
+    color: "0052cc"
     description: Documentation-only work.
   - name: type:question
     color: d4c5f9
     description: Support, clarification, or usage question.
   - name: type:maintenance
-    color: '531999'
+    color: "531999"
     description: Non-feature maintenance, cleanup, or org work.
   - name: type:membership
     color: 6f42c1
     description: Membership and organization-role requests.
   - name: type:handoff
-    color: '5319e7'
+    color: "5319e7"
     description: Cross-agent or cross-maintainer handoff context.
 
   # Area
@@ -51,10 +51,10 @@ labels:
     color: 3e16f3
     description: Package or package-management work.
   - name: area:docs
-    color: '0052cc'
+    color: "0052cc"
     description: Documentation systems, content, or publishing.
   - name: area:ci
-    color: '5319e7'
+    color: "5319e7"
     description: Continuous integration or GitHub Actions work.
   - name: area:dependencies
     color: fbca04
@@ -89,10 +89,10 @@ labels:
     color: f9d0c4
     description: Waiting on more detail before work can continue.
   - name: good first issue
-    color: '7057ff'
+    color: "7057ff"
     description: Well-scoped starter task for a new contributor.
   - name: help wanted
-    color: '008672'
+    color: "008672"
     description: Maintainers would welcome outside help.
   - name: invalid
     color: 0b467f
@@ -104,17 +104,17 @@ labels:
     color: ffffff
     description: Acknowledged but not planned for implementation.
   - name: meta:org-tracked
-    color: '5319e7'
+    color: "5319e7"
     description: Indicates this issue has cross-repository tracking implications (synced to Linear).
 
   # External automation labels retained for compatibility.
   # These are not part of the triage taxonomy but appear in z-shell/.github
   # and are commonly managed by Dependabot / dependency automation.
   - name: dependencies
-    color: '0366d6'
+    color: "0366d6"
     description: Pull requests that update a dependency file
   - name: github_actions
-    color: '000000'
+    color: "000000"
     description: Pull requests that update GitHub Actions code
 
 legacy_migrations:

--- a/runbooks/labels.md
+++ b/runbooks/labels.md
@@ -44,6 +44,7 @@ The org tracker auto-add label is `meta:org-tracked`.
 - `priority:high`
 - `regression`
 - `security`
+- `performance`
 - `breaking-change`
 - `status:triage`
 - `status:blocked`
@@ -87,6 +88,7 @@ Common legacy labels:
 | `help-wanted`              | `help wanted`       |
 | `breaking-change 💥`       | `breaking-change`   |
 | `security 🛡️`              | `security`          |
+| `performance 🚀`           | `performance`       |
 | `invalid ⚠️`               | `invalid`           |
 
 Also retire spaced namespace variants such as `type: bug`, `area: docs`, `priority: high`, and `status: triage`.

--- a/runbooks/triage.md
+++ b/runbooks/triage.md
@@ -62,6 +62,7 @@ The organization label set in `.github/lib/labels.yml` is the source of truth. A
 | high priority          | `priority:high`    |
 | breaking change        | `breaking-change`  |
 | security-sensitive     | `security`         |
+| performance-sensitive  | `performance`      |
 | good first issue       | `good first issue` |
 | help wanted            | `help wanted`      |
 | invalid                | `invalid`          |


### PR DESCRIPTION
Closes #462.

## Problem

Repos across the org carry a local `performance 🚀` label (`#006b75`) with no canonical equivalent and no `legacy_migrations` entry. `sync_policy` therefore treats it as an unknown local label: preserved on the issues that have it, but never migrated, and never created in repos that lack it.

Surfaced while relabelling z-shell/zsh-fancy-completions#47. The migration table cleanly resolved `bug 🐞`, `ci 🤖`, `enhancement ✨`, and `plugin ⚙️`; `performance 🚀` had nowhere to go. That left two related issues inconsistent — #47 kept the legacy label (correctly preserved), while zsh-fancy-completions#49, the benchmark issue supporting it, carries no performance signal at all, because applying the legacy form to a *new* issue would reintroduce exactly what the taxonomy exists to remove.

## Change

Adds `performance` as a **severity/modifier**, alongside `regression`, `security`, and `breaking-change`. Those mark cross-cutting concerns rather than work types, which is the right shape here: performance work can be a bug, a maintenance task, or a feature, and the `type:` axis already carries that distinction.

```yaml
- name: performance
  color: "006b75"
  description: Performance-sensitive work or a measured regression in speed or memory.
```

Colour reuses the `#006b75` repos already apply, so migrating an existing label is visually seamless and a later sync is a no-op.

Also updates the two human enumerations that define the canonical set — `runbooks/labels.md` (modifiers list and legacy migration table) and `runbooks/triage.md` (severity table). A canonical label missing from the canonical-labels runbook is only half-added.

## Two commits, deliberately

`lib/labels.yml` predates Prettier, so touching it triggers a quote-style rewrite on 8 unrelated lines. Per `CLAUDE.md` ("separate mechanical cleanup from behavioral change") that churn is isolated in `dbfd9ce`, leaving the second commit a clean 7-line addition. Review `22e0507` for the actual decision.

## `.github/lib/labels.yml` is deliberately untouched

That second copy is a stale duplicate the tooling does not read — `scripts/labels-sync.rb` uses `DEFAULT_LABELS_FILE = lib/labels.yml`. It is missing `legacy_migrations`, `sync_policy`, and the automation labels, and its `meta:org-tracked` description still describes the retired GitHub Projects tracker. Adding one label to it would imply it is maintained.

Filed separately as #461, including the detail that all 8 documentation references point at the stale copy — so a maintainer who follows the runbook edits a dead file and their change silently does nothing.

## Verification

`scripts/labels-sync.rb --repo z-shell/zsh-fancy-completions` now reports, where it previously reported neither:

```
Canonical labels: 32          (was 31)
Legacy migrations: 31         (was 30)
### Would create
- performance
### Legacy labels present
- performance 🚀 -> performance
```

`trunk check --filter=prettier,markdownlint` clean on all three files.

## Follow-up

Once merged, `performance` should be created in z-shell/zsh-fancy-completions and applied to #47 (replacing the legacy label) and #49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)