### PR TITLE
docs: correct the disallowed-trailer enforcement claim

### DIFF
--- a/decisions/0009-testing-ci-strategy.md
+++ b/decisions/0009-testing-ci-strategy.md
@@ -35,10 +35,14 @@ common baseline; higher-risk classes add to it.
 - Zsh sources pass `zsh -n` (syntax) and `zcompile` (compile) checks.
 - Dependency and secret scanning per `decisions/0004-dependabot-unification.md`.
 - **Target state (not yet a live org-wide control):** Conventional Commits
-  (ADR-0003) and the disallowed-trailer rule enforced in CI. Today the
-  disallowed-trailer check runs via the `DISALLOWED_TRAILER_PATTERN` org secret;
-  Conventional Commits is convention-and-review, not a uniform CI gate. Adding a
-  shared commit/PR-title-lint check is a follow-up, tracked separately.
+  (ADR-0003) and the disallowed-trailer rule enforced in CI. Neither is a live
+  org-wide gate today: a sweep of every repository's default branch found no
+  workflow that runs the `DISALLOWED_TRAILER_PATTERN` check or validates commit
+  messages. The only implementation is a `commit-lint` workflow on the `next`
+  branch of `z-shell/zi`, which has never reached a default branch. Both the
+  trailer ban and Conventional Commits are convention-and-review until a shared
+  commit/PR-title-lint check is promoted into a reusable workflow here and rolled
+  out; that work is tracked separately.
 
 ### By class
 

--- a/decisions/0009-testing-ci-strategy.md
+++ b/decisions/0009-testing-ci-strategy.md
@@ -36,9 +36,11 @@ common baseline; higher-risk classes add to it.
 - Dependency and secret scanning per `decisions/0004-dependabot-unification.md`.
 - **Target state (not yet a live org-wide control):** Conventional Commits
   (ADR-0003) and the disallowed-trailer rule enforced in CI. Neither is a live
-  org-wide gate today: a sweep of every repository's default branch found no
-  workflow that runs the `DISALLOWED_TRAILER_PATTERN` check or validates commit
-  messages. The only implementation is a `commit-lint` workflow on the `next`
+  org-wide gate today: a sweep of the default branches of all 86 active,
+  non-fork, non-archived repositories found no workflow that runs the
+  `DISALLOWED_TRAILER_PATTERN` check or validates commit messages. Non-default
+  branches were not swept. The only implementation is a `commit-lint` workflow
+  on the `next`
   branch of `z-shell/zi`, which has never reached a default branch. Both the
   trailer ban and Conventional Commits are convention-and-review until a shared
   commit/PR-title-lint check is promoted into a reusable workflow here and rolled

--- a/runbooks/onboarding.md
+++ b/runbooks/onboarding.md
@@ -44,8 +44,8 @@ Grant only what the role requires; record the grant:
   clone.
 - Configure commit signing: commits are signed (`gpg.format=ssh`); set a
   `user.signingkey`. Never add a `Co-authored-by` trailer — this is org policy,
-  and note that no default-branch CI currently enforces it, so it is author's
-  responsibility, not a gate that will catch a mistake.
+  and note that no default-branch CI currently enforces it, so it is the
+  author's responsibility, not a gate that will catch a mistake.
 - Follow Conventional Commits and the branch model for the repo's class
   (ADR-0008).
 

--- a/runbooks/onboarding.md
+++ b/runbooks/onboarding.md
@@ -43,8 +43,9 @@ Grant only what the role requires; record the grant:
   worktrees do not check out submodules** — child-repo work happens in the main
   clone.
 - Configure commit signing: commits are signed (`gpg.format=ssh`); set a
-  `user.signingkey`. CI rejects the disallowed-trailer pattern, so never add a
-  `Co-authored-by` trailer.
+  `user.signingkey`. Never add a `Co-authored-by` trailer — this is org policy,
+  and note that no default-branch CI currently enforces it, so it is author's
+  responsibility, not a gate that will catch a mistake.
 - Follow Conventional Commits and the branch model for the repo's class
   (ADR-0008).
 


### PR DESCRIPTION
Closes #464.

## What

Two docs claimed the `Co-authored-by` trailer ban is enforced in CI. It is not.

- `decisions/0009-testing-ci-strategy.md` said the check "runs today via the `DISALLOWED_TRAILER_PATTERN` org secret."
- `runbooks/onboarding.md` said "CI rejects the disallowed-trailer pattern."

A sweep of all 86 active repositories' default branches (git trees + contents API, not code search) found **zero** workflows that run the check or validate commit messages. The only implementation is a `commit-lint` workflow on the **`next`** branch of `z-shell/zi`, which has never reached a default branch.

## Change

Both docs now state the ban is convention-and-review — enforced by authors, not CI — until a shared commit-lint workflow is promoted into this repo and rolled out. The rule itself (never add the trailer) is unchanged.

## Scope

This closes the *inaccuracy*. Building the org-wide enforcement is deliberately **not** in this PR; it was the larger half of #464 and is blocked on a separate decision (the `feat/…` vs `feature-<id>` branch-naming contradiction between `commit-lint.yml` and the workspace `AGENTS.md`). If that build-out is wanted, it should be its own issue with the branch-naming question resolved first.