### PR TITLE
ci(labels): run the labels-sync test suite on tooling changes

### DIFF
--- a/.github/workflows/labels-sync-test.yml
+++ b/.github/workflows/labels-sync-test.yml
@@ -1,0 +1,46 @@
+---
+name: Labels Sync Tests
+on:
+  workflow_call: {}
+  push:
+    paths:
+      - "scripts/labels-sync.rb"
+      - "scripts/labels-dry-run.rb"
+      - "scripts/test-labels-dry-run.sh"
+      - "lib/labels.yml"
+      - ".github/workflows/labels-sync-test.yml"
+  pull_request:
+    paths:
+      - "scripts/labels-sync.rb"
+      - "scripts/labels-dry-run.rb"
+      - "scripts/test-labels-dry-run.sh"
+      - "lib/labels.yml"
+      - ".github/workflows/labels-sync-test.yml"
+  workflow_dispatch: {}
+
+# The suite runs read-only previews against this repository, so it needs to read
+# labels and issues. It never passes a --confirm-* flag, and the script refuses
+# every destructive path without one.
+permissions:
+  contents: read
+  issues: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  labels-sync-test:
+    name: Labels Sync Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: "⤵️ Check out code from GitHub"
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: "⚙️ Report Ruby version"
+        run: ruby --version
+
+      - name: "🧪 Run labels-sync smoke tests"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: sh scripts/test-labels-dry-run.sh


### PR DESCRIPTION
Closes #469.

## Why

No workflow in this repository executes `scripts/`, so `scripts/test-labels-dry-run.sh` ran only when someone remembered to. That suite caught two real defects during #466:

- an in-use legacy label being queued for deletion
- a migration deleting the legacy label **before** relabelling the items that carried it

Either would have destroyed label associations across the organization. A third — a race between planning and deletion — was found in review and is now covered too.

An untriggered test suite is the same failure #464 documented: a control that exists in the repo but not in reality.

## What

Runs the suite on pushes and pull requests touching `scripts/labels-sync.rb`, `scripts/labels-dry-run.rb`, `scripts/test-labels-dry-run.sh`, or `lib/labels.yml`.

## Permissions

The suite makes **read-only preview** calls against this repository (it resolves live labels and issues to compute drift), so the job takes `contents: read` and `issues: read` and passes `GH_TOKEN`. It never supplies a `--confirm-*` flag, and the script refuses every destructive path without one — the guardrail tests in the suite assert exactly that.

## Verification

Not assumed to work:

| Check | Result |
| --- | --- |
| YAML parses, permissions as intended | pass |
| Suite passes via the exact CI invocation (`sh scripts/test-labels-dry-run.sh` from repo root) | pass |
| Same invocation against a **deliberately broken** script | **exits 1** |
| Same invocation against the restored script | exits 0 |

`actions/checkout` is pinned to `df4cb1c069e1874edd31b4311f1884172cec0e10`, verified against the API as **v6.0.3** rather than copied on trust.

## Noted, not changed

Two existing workflows in this repo pin that same SHA but comment it `# v4`, while nine comment it `# v6.0.3`. The API confirms v6.0.3, so those two comments are stale and misleading. Out of scope here.