### PR TITLE
docs(runbook): require post-promotion reconciliation

### DIFF
--- a/runbooks/branch-protection.md
+++ b/runbooks/branch-protection.md
@@ -66,10 +66,13 @@ row is `next` → `main`. Skip repositories that are trunk-on-`main`.
       branch" condition, so this has to be a CI check wired in as
       `required_status_checks`. See `.github/workflows/main-branch-guard.yml`
       in `z-shell/src` or `z-shell/zsh-eza` for the reference implementation
-      (a single `run:` step reading `github.head_ref`, no third-party
-      actions needed). The check must run at least once on a real PR against
-      `main` before GitHub will accept its context name in
-      `required_status_checks`.
+      (a single `run:` step, no third-party actions needed). The check must
+      first require `github.event.pull_request.head.repo.full_name` to equal
+      `github.repository`, because a fork can reuse an allowed branch name.
+      It can then allow only `github.head_ref == 'next'` or
+      `github.head_ref` matching `hotfix-*`. The check must run at least once
+      on a real PR against `main` before GitHub will accept its context name
+      in `required_status_checks`.
 
 ## Squash-merge trailers
 
@@ -84,6 +87,38 @@ one-line `--body` (e.g. `gh pr merge <n> --squash --subject "..." --body "..."`)
 the synthesized body. Verify with
 `gh api repos/<org>/<repo>/commits/<sha> --jq .commit.message` before
 considering the promotion done.
+
+## Post-promotion reconciliation
+
+A squash merge keeps `main` linear but creates a new commit that is not in
+`next`, even when the resulting branch trees are identical. If that commit is
+not merged back, the next promotion uses an older merge base and can show
+already-promoted changes or produce avoidable conflicts.
+
+Immediately after a successful squash promotion:
+
+1. Fetch the current `main` and `next`, then verify the promoted `main` tree
+   matches the reviewed `next` tree:
+
+   ```bash
+   git fetch origin main next
+   git diff --exit-code origin/main origin/next
+   ```
+
+2. Create an issue branch from the current `next`, merge `origin/main` with a
+   signed, non-fast-forward merge commit, and preserve the pre-merge `next`
+   tree exactly. Open a PR from that issue branch into `next` and merge it
+   with a merge commit so the `main` parent remains in history.
+3. Fetch both branches again and verify `main` is now an ancestor of `next`:
+
+   ```bash
+   git fetch origin main next
+   git merge-base --is-ancestor origin/main origin/next
+   ```
+
+Do not reset, rebase, force-push, or replace the persistent `next` branch to
+perform this reconciliation. If the branch trees differ before the back-merge,
+stop and review the delta instead of resolving it as an ancestry-only change.
 
 ## Reference ruleset shape
 

--- a/runbooks/branch-protection.md
+++ b/runbooks/branch-protection.md
@@ -105,10 +105,22 @@ Immediately after a successful squash promotion:
    git diff --exit-code origin/main origin/next
    ```
 
-2. Create an issue branch from the current `next`, merge `origin/main` with a
-   signed, non-fast-forward merge commit, and preserve the pre-merge `next`
-   tree exactly. Open a PR from that issue branch into `next` and merge it
-   with a merge commit so the `main` parent remains in history.
+2. Create the signed merge commit on an issue branch from the current `next`
+   and verify it preserves the pre-merge `next` tree:
+
+   ```bash
+   next_tree=$(git rev-parse 'origin/next^{tree}')
+   git switch -c <issue-branch> origin/next
+   git merge --no-ff -S origin/main \
+     -m "chore: reconcile promoted main into next (#<issue>)"
+   test "$(git rev-parse 'HEAD^{tree}')" = "$next_tree"
+   git push -u origin <issue-branch>
+   ```
+
+   Open a PR from `<issue-branch>` into `next`. Merge it with **Create a merge
+   commit** so the `main` parent remains in history. Do not squash or rebase
+   this reconciliation PR.
+
 3. Fetch both branches again and verify `main` is now an ancestor of `next`:
 
    ```bash


### PR DESCRIPTION
## Summary

- require post-squash `main`-to-`next` reconciliation for repositories using the `next` to `main` model
- document exact tree-equality and ancestry verification
- prohibit reset, rebase, force-push, or branch replacement as reconciliation shortcuts
- correct the source-guard reference to validate head-repository identity before branch name

## Evidence

In `z-shell/zsh-eza`, a prior squash promotion left its new `main` commit outside `next`. The next promotion then required a dedicated reconciliation and produced four avoidable workflow conflicts. PRs z-shell/zsh-eza#88 and #90 demonstrate the promotion and immediate ancestry-only back-merge sequence this runbook now documents.

## Instruction impact review

1. Classification: operational runbook guidance, not a new policy decision, runtime adapter, or enforcement mechanism.
2. Consumers: maintainers, humans, and all supported agent runtimes operating on repositories assigned the `next` to `main` model.
3. Canonical owner: `runbooks/branch-protection.md` remains the correct owner because this is a repeatable branch-protection and promotion procedure.
4. Duplication or contradiction: ADR-0008 owns the branch model and this runbook already owns promotion mechanics. No equivalent post-promotion reconciliation instruction exists. The former head-ref-only guard reference was incomplete.
5. Manifest impact: none. The existing required `branch-protection` route already selects this runbook.
6. Runtime delivery: unchanged. Every supported runtime receives the mandatory runbook through the required instruction manifest route, without optional hooks or skills.
7. Generated output and size: unaffected because neither `AGENTS.md` nor an adapter changes.

## Validation

- `python3 scripts/validate-agent-policy.py`
- `python3 -m unittest scripts/test_validate_agent_policy.py -v` (68 passed)
- `trunk check runbooks/branch-protection.md --no-progress`
- Markdown content-contract and diff checks

Closes #483