### PR TITLE
fix(ci): avoid reusable workflow concurrency deadlock

### DIFF
--- a/.github/workflows/zsh-lint.yml
+++ b/.github/workflows/zsh-lint.yml
@@ -15,10 +15,8 @@ on:
 
 permissions: {}
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
+# The calling workflow owns concurrency. Reusing its group here deadlocks
+# GitHub Actions because the called workflow cannot acquire the active group.
 jobs:
   zsh-lint:
     name: Zsh Lint


### PR DESCRIPTION
Part of #505.

Removes the duplicate concurrency group from the called workflow. Each caller retains its own cancellation-safe group; defining the same group in both layers causes GitHub Actions to cancel the call as a deadlock.