### PR TITLE
fix(ci): disable caller go cache in zsh-lint

### DIFF
--- a/.github/workflows/zsh-lint.yml
+++ b/.github/workflows/zsh-lint.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
+          # The calling repository need not be Go-based. zsh-lint is checked
+          # out separately, so dependency-cache discovery here is irrelevant.
+          cache: false
           go-version: "1.25"
 
       - name: Build zsh-lint


### PR DESCRIPTION
Part of #505.

Disables `setup-go` dependency caching because the caller repository is not necessarily Go-based. The reusable workflow checks out `zsh-lint` separately, so automatic cache discovery emits an irrelevant warning without improving this gate.