### PR TITLE
docs(branching): propose promotion trigger criteria (ADR 0016)

### DIFF
--- a/.github/instruction-surfaces.json
+++ b/.github/instruction-surfaces.json
@@ -726,6 +726,18 @@
       "canonical_for": []
     },
     {
+      "id": "decision-0016",
+      "path": "decisions/0016-promotion-trigger-criteria.md",
+      "kind": "decision",
+      "authority": "canonical-detail",
+      "consumers": ["codex", "claude-code", "copilot", "gemini-cli", "human"],
+      "tasks": ["architecture-decision"],
+      "file_patterns": ["**"],
+      "required": true,
+      "review_owner": "z-shell maintainers",
+      "canonical_for": []
+    },
+    {
       "id": "zsh-standard-policy",
       "path": "lib/zsh-standard-policy.json",
       "kind": "enforcement",

--- a/.github/workflows/promote-prepare.yml
+++ b/.github/workflows/promote-prepare.yml
@@ -1,0 +1,174 @@
+---
+name: Promote Prepare
+
+# DRAFT / PoC — accompanies decisions/0016-promotion-trigger-criteria.md
+# (PROPOSED). Not called by any repository yet; wiring a caller into wiki,
+# src, zi, zsh-eza, or zsh-lint is follow-up work for after the ADR is
+# accepted.
+#
+# Prepares — but never merges — a next -> main (or equivalent) promotion for
+# decisions/0008-branching-model.md repositories. On the caller's chosen
+# trigger it checks whether the development branch is ahead of the deployed
+# branch, whether it has cleared the repository's bake window, and whether
+# any open issue carries the blocking label. If all three hold, it opens or
+# updates a single promotion pull request. The maintainer merge remains the
+# only publication act, per ADR-0008.
+
+on:
+  workflow_call:
+    inputs:
+      dev-branch:
+        description: Development branch to promote from.
+        required: false
+        type: string
+        default: "next"
+      deploy-branch:
+        description: Deployed/published branch to promote into.
+        required: false
+        type: string
+        default: "main"
+      bake-minutes:
+        description: >
+          Minimum age, in minutes, of the development branch's tip commit
+          before a promotion is proposed. 0 disables the bake window.
+        required: false
+        type: number
+        default: 0
+      blocking-label:
+        description: >
+          Open issues carrying this label suppress the proposal. Reuses the
+          existing triage taxonomy (lib/labels.yml) rather than a dedicated
+          label.
+        required: false
+        type: string
+        default: "status:blocked"
+      pr-label:
+        description: Label applied to the promotion pull request (created when missing).
+        required: false
+        type: string
+        default: "promotion-proposal"
+    outputs:
+      proposed:
+        description: >
+          "true" when a promotion pull request was created or updated;
+          empty otherwise.
+        value: ${{ jobs.propose.outputs.proposed }}
+      skipped-reason:
+        description: Human-readable reason no proposal was made, when applicable.
+        value: ${{ jobs.propose.outputs.skipped-reason }}
+  workflow_dispatch: {}
+
+# Callers own concurrency; use cancel-in-progress: false on the promotion path.
+permissions:
+  contents: read
+  issues: read
+  pull-requests: write
+
+jobs:
+  propose:
+    runs-on: ubuntu-latest
+    outputs:
+      proposed: ${{ steps.pr.outputs.proposed }}
+      skipped-reason: ${{ steps.gate.outputs.skipped-reason }}
+    steps:
+      - name: ⤵️ Check out code from GitHub
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: 🚦 Evaluate promotion readiness
+        id: gate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DEV_BRANCH: ${{ inputs.dev-branch || 'next' }}
+          DEPLOY_BRANCH: ${{ inputs.deploy-branch || 'main' }}
+          BAKE_MINUTES: ${{ inputs.bake-minutes || 0 }}
+          BLOCKING_LABEL: ${{ inputs.blocking-label || 'status:blocked' }}
+        run: |
+          set -euo pipefail
+
+          git fetch origin "$DEV_BRANCH" "$DEPLOY_BRANCH"
+
+          ahead="$(git rev-list --count "origin/${DEPLOY_BRANCH}..origin/${DEV_BRANCH}")"
+          if [ "$ahead" -eq 0 ]; then
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "skipped-reason=${DEV_BRANCH} has no commits ahead of ${DEPLOY_BRANCH}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$BAKE_MINUTES" -gt 0 ]; then
+            tip_epoch="$(git log -1 --format=%ct "origin/${DEV_BRANCH}")"
+            now_epoch="$(date +%s)"
+            age_minutes=$(( (now_epoch - tip_epoch) / 60 ))
+            if [ "$age_minutes" -lt "$BAKE_MINUTES" ]; then
+              echo "ready=false" >> "$GITHUB_OUTPUT"
+              echo "skipped-reason=${DEV_BRANCH} tip is ${age_minutes}m old, below the ${BAKE_MINUTES}m bake window" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+
+          blocked="$(gh issue list --repo "$GITHUB_REPOSITORY" --state open \
+            --label "$BLOCKING_LABEL" --json number --jq 'length')"
+          if [ "$blocked" -gt 0 ]; then
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "skipped-reason=${blocked} open issue(s) labeled ${BLOCKING_LABEL}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "ready=true" >> "$GITHUB_OUTPUT"
+          echo "ahead=${ahead}" >> "$GITHUB_OUTPUT"
+
+      - name: 📝 Open or update promotion pull request
+        id: pr
+        if: steps.gate.outputs.ready == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DEV_BRANCH: ${{ inputs.dev-branch || 'next' }}
+          DEPLOY_BRANCH: ${{ inputs.deploy-branch || 'main' }}
+          PR_LABEL: ${{ inputs.pr-label || 'promotion-proposal' }}
+          AHEAD: ${{ steps.gate.outputs.ahead }}
+        run: |
+          set -euo pipefail
+
+          body="$(mktemp)"
+          {
+            echo "Automated promotion proposal from the reusable [Promote Prepare](https://github.com/z-shell/.github/blob/main/.github/workflows/promote-prepare.yml) workflow."
+            echo
+            echo "- **${DEV_BRANCH} is ${AHEAD} commit(s) ahead of ${DEPLOY_BRANCH}.**"
+            echo "- **Diff:** ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/compare/${DEPLOY_BRANCH}...${DEV_BRANCH}"
+            echo
+            echo "## To merge"
+            echo
+            echo "Per [ADR 0008](https://github.com/z-shell/.github/blob/main/decisions/0008-branching-model.md) this merge is the publication act. Follow"
+            echo "[runbooks/branch-protection.md](https://github.com/z-shell/.github/blob/main/runbooks/branch-protection.md):"
+            echo
+            echo "1. Confirm no unexpected divergence: \`git diff --exit-code origin/${DEPLOY_BRANCH} origin/${DEV_BRANCH}\` after review commits, if any, are accounted for."
+            echo "2. Squash-merge with an explicit \`--subject\` and \`--body\` (never let GitHub synthesize one, or a stray \`Co-authored-by\` trailer reappears)."
+            echo "3. Verify the resulting commit message before considering the promotion done."
+            echo "4. Run the post-promotion back-merge in the runbook so ${DEV_BRANCH} does not diverge from ${DEPLOY_BRANCH}."
+            echo
+            echo "_Updated automatically per the trigger this repository configured; closing this PR without merging skips the promotion._"
+          } > "$body"
+
+          gh label create "$PR_LABEL" \
+            --repo "$GITHUB_REPOSITORY" \
+            --description "Automated next-to-main promotion proposal awaiting a maintainer merge." \
+            --color 0E8A16 2> /dev/null || true
+
+          existing="$(gh pr list --repo "$GITHUB_REPOSITORY" --state open \
+            --base "$DEPLOY_BRANCH" --head "$DEV_BRANCH" --json number --jq '.[0].number // empty')"
+          title="Promote ${DEV_BRANCH} to ${DEPLOY_BRANCH}"
+          if [ -n "$existing" ]; then
+            gh pr edit "$existing" --repo "$GITHUB_REPOSITORY" \
+              --title "$title" --body-file "$body"
+            echo "Updated promotion pull request #${existing}."
+          else
+            gh pr create --repo "$GITHUB_REPOSITORY" \
+              --base "$DEPLOY_BRANCH" --head "$DEV_BRANCH" \
+              --title "$title" --body-file "$body" --label "$PR_LABEL" ||
+              gh pr create --repo "$GITHUB_REPOSITORY" \
+                --base "$DEPLOY_BRANCH" --head "$DEV_BRANCH" \
+                --title "$title" --body-file "$body"
+            echo "Created promotion pull request."
+          fi
+          echo "proposed=true" >> "$GITHUB_OUTPUT"

--- a/decisions/0016-promotion-trigger-criteria.md
+++ b/decisions/0016-promotion-trigger-criteria.md
@@ -1,0 +1,130 @@
+# 16. Next-to-Main Promotion Trigger Criteria
+
+- **Status:** PROPOSED
+- **Date:** 2026-08-16
+- **Deciders:** Pending maintainer acceptance
+- **Supersedes:** None
+- **Superseded by:** None
+
+## Context
+
+`decisions/0008-branching-model.md` establishes which repositories use the
+`next` → `main` branch model (`wiki`, `src`, `zi`, `zsh-lint`, `zsh-eza`) and
+states that promotion is a publication trigger for class-1 deploy repos.
+`runbooks/branch-protection.md` and `runbooks/release.md` cover how a
+promotion is protected (rulesets, `delete_branch_on_merge`, the main-branch
+guard) and how it is reconciled afterward (the mandatory back-merge). None of
+those documents states **when** a promotion should happen. That decision is
+currently pure maintainer judgment, undocumented and unaudited — a gap
+identified in [z-shell/.github#513](https://github.com/z-shell/.github/issues/513).
+
+A working precedent already exists for automating a readiness *signal*
+without automating the merge decision itself: `release-prepare.yml`
+(class 2, ADR-0007) opens or updates a proposal issue with a draft changelog
+when releasable commits land on the default branch, but a maintainer still
+pushes the annotated tag that actually publishes. The same "propose, don't
+merge" shape is the natural fit for `next` → `main` promotion, since ADR-0008
+already treats promotion as a deliberate publication act, not a
+side-effect of CI going green.
+
+The five `next` → `main` repositories do not share the same cost of staleness
+or the same blast radius from a bad promotion:
+
+- `wiki`, `src` (class 1, deploy): a promotion triggers a deploy. A bad
+  promotion is user-visible immediately.
+- `zi`, `zsh-eza` (class 3, consumable ref): `main` is the ref consumers pull
+  directly. Staleness has a direct, ongoing cost; there is no deploy step to
+  protect against.
+- `zsh-lint` (class 2): `next` feeds a `vX.Y.Z` release tag, and
+  `release-prepare.yml` already computes readiness for that tag from commits
+  on the default branch.
+
+A single trigger rule for all five would either under-protect the deploy
+repos or over-delay the consumable-ref repos.
+
+## Decision
+
+Adopt **readiness-proposal automation** as the default promotion-trigger
+mechanism for every `next` → `main` repository, implemented as a reusable
+`promote-prepare.yml` workflow (mirrors `release-prepare.yml`'s shape):
+
+- On a trigger the caller repository chooses (push to the development branch,
+  or a schedule), the workflow checks whether the development branch is ahead
+  of the deployed branch, whether it has been green for the repository's
+  configured bake window, and whether any open issue carries the
+  `status:blocked` label (reused from the existing triage taxonomy —
+  `lib/labels.yml` — rather than adding a new label).
+- If all three conditions hold, it opens or updates a single
+  development-branch → deployed-branch pull request. It never merges. The PR
+  body restates the `runbooks/branch-protection.md` merge requirements
+  (explicit `--subject`/`--body` on the squash, verify the resulting commit
+  message, run the post-promotion back-merge) so the human merging it has the
+  checklist in front of them.
+- A maintainer merges the PR through the existing documented path
+  (`gh pr merge --admin`, since the sole `CODEOWNERS` entry is typically also
+  the author — this mirrors the bypass pattern `branch-protection.md` already
+  documents as normal, not an escape hatch).
+
+### Per-repository bake window
+
+The bake window is the only per-repository parameter; everything else about
+the mechanism is uniform.
+
+| Repo        | Class | Bake window | Rationale                                                        |
+| ----------- | ----- | ----------- | ------------------------------------------------------------------ |
+| `wiki`      | 1     | 2 hours     | Gives delayed CI/nightly checks a chance to fail before a deploy. |
+| `src`       | 1     | 2 hours     | Same as `wiki`; installer/loader validation can be slow.          |
+| `zi`        | 3     | 0 (none)    | `main` is the consumable ref; staleness costs consumers directly. |
+| `zsh-eza`   | 3     | 0 (none)    | Same rationale as `zi`.                                            |
+| `zsh-lint`  | 2     | 0 (none)    | Readiness already gated by `release-prepare.yml`'s own signal.    |
+
+These are starting values, not load-bearing constants — a maintainer can tune
+a given repository's bake window without amending this ADR, the same way
+`runbooks/branch-protection.md`'s checklist items are tunable enforcement
+detail under ADR-0008's table.
+
+## Consequences
+
+- Every `next` → `main` repository gets a documented, auditable answer to
+  "why hasn't this been promoted yet" instead of relying on someone noticing.
+- The publication boundary stays a deliberate human act (a merge), consistent
+  with ADR-0008; no repository auto-merges into `main`.
+- `status:blocked` gains a second meaning in practice (general triage hold,
+  and now promotion hold). If that overloading proves confusing in practice,
+  a dedicated label can be introduced later without changing this ADR's
+  mechanism.
+- `wiki` and `src` gain a 2-hour minimum lag between "`next` is ready" and
+  "a promotion PR exists." That is a deliberate cost traded for catching
+  delayed CI failures before they deploy.
+- This does not change ADR-0008's per-repository branch-model table, only
+  which of those repositories' promotions get an automated readiness signal.
+
+## Alternatives considered
+
+- **Continuous promotion on every green commit.** Rejected as the default:
+  no margin for delayed/nightly failures on `wiki`/`src`, where a bad
+  promotion is immediately user-visible.
+- **Fixed cadence (daily/weekly) for all five repos.** Rejected: a poor fit
+  for `zi`/`zsh-eza`, where consumers pull `main` directly and a week of
+  staleness has a real, ongoing cost with no compensating safety benefit.
+- **One org-wide bake window instead of per-repo.** Rejected: applying the
+  deploy repos' 2-hour window to `zi`/`zsh-eza` would add pure latency with
+  no corresponding risk to protect against, since those repos have no deploy
+  step.
+- **Leave it fully manual (status quo).** Rejected: this is the gap
+  `z-shell/.github#513` identified — it does not scale and is not auditable.
+
+## References
+
+- `decisions/0008-branching-model.md` — branch model and publication-trigger
+  language this decision narrows.
+- `decisions/0007-release-publication-flow.md` — the readiness-proposal
+  precedent (`release-prepare.yml`).
+- `runbooks/branch-protection.md` — merge mechanics the promotion PR body
+  must restate (squash trailers, admin-bypass path, post-promotion reconcile).
+- `runbooks/release.md` — `release-prepare.yml` reference implementation.
+- `lib/labels.yml` — `status:blocked`, reused rather than duplicated.
+- [z-shell/.github#513](https://github.com/z-shell/.github/issues/513) — the
+  issue this ADR resolves.
+- `.github/workflows/promote-prepare.yml` — draft reference implementation
+  (PoC, not yet called by any repository).


### PR DESCRIPTION
## Summary

Proposes an answer to the gap identified in #513: ADR-0008 defines *which*
repositories promote `next` -> `main` and that promotion is a publication
trigger for class-1 repos, but nothing states *when* a promotion should
happen. This PR adds:

1. **`decisions/0016-promotion-trigger-criteria.md`** — a `PROPOSED` ADR
   (not accepted; per `runbooks/adr.md` only a maintainer can flip that).
   Recommends readiness-proposal automation (mirroring the existing
   `release-prepare.yml` precedent) with a per-repository bake window:
   2 hours for `wiki`/`src` (deploy risk), none for `zi`/`zsh-eza`
   (staleness costs consumers directly), none for `zsh-lint` (already gated
   by `release-prepare.yml`'s own signal).
2. **`.github/workflows/promote-prepare.yml`** — a draft reusable workflow
   implementing that mechanism as a PoC. It opens/updates a single
   `next -> main` pull request when the dev branch is ahead, has cleared
   the bake window, and no open issue carries `status:blocked` (reusing the
   existing label rather than adding a new one). **It never merges** — the
   PR body restates the `runbooks/branch-protection.md` merge checklist
   (explicit `--subject`/`--body`, verify the commit, run the post-promotion
   back-merge) for whoever merges it.

**Not done here:** no repository (`wiki`, `src`, `zi`, `zsh-eza`,
`zsh-lint`) is wired to call this workflow. That's follow-up work once the
ADR is accepted or amended by a maintainer.

## Why draft

Per `runbooks/adr.md`, new ADRs start `PROPOSED` and only ss-o can accept
one. This PR is for review/discussion, not merge-on-green.

Refs #513

🤖 Generated with [Claude Code](https://claude.com/claude-code)
