### PR TITLE
chore(adr): accept ADR 0016 (promotion trigger criteria)

### DIFF
--- a/decisions/0016-promotion-trigger-criteria.md
+++ b/decisions/0016-promotion-trigger-criteria.md
@@ -1,8 +1,8 @@
 # 16. Next-to-Main Promotion Trigger Criteria
 
-- **Status:** PROPOSED
+- **Status:** ACCEPTED
 - **Date:** 2026-08-16
-- **Deciders:** Pending maintainer acceptance
+- **Deciders:** ss-o
 - **Supersedes:** None
 - **Superseded by:** None
 


### PR DESCRIPTION
Flips `decisions/0016-promotion-trigger-criteria.md` from `PROPOSED` to `ACCEPTED`, records `Deciders: ss-o`.

Per `runbooks/adr.md`, acceptance happens on `main` via a merged PR, not a status edit on a feature branch that never lands. Requested directly by ss-o.

Refs #513