### PR TITLE
ci(commit-lint): enforce disallowed-trailer and commit policy

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -1,0 +1,115 @@
+---
+name: Commit Lint
+
+# Org-wide commit-message, PR-title, and branch-naming policy, promoted from
+# z-shell/zi's next-branch-only commit-lint.yml (z-shell/.github#464). Enforces
+# the AGENTS.md rules that were previously "author-enforced" only: the
+# disallowed Co-authored-by trailer (organization-wide ban, decisions/0003),
+# Conventional Commits (decisions/0003), and feature-<id>/bug-<id>/hotfix-<id>
+# branch naming (decisions/0008).
+
+on:
+  workflow_call:
+    inputs:
+      disallowed-trailer-pattern:
+        description: Case-insensitive grep -E pattern for a banned commit trailer.
+        required: false
+        type: string
+        default: "^[[:space:]]*Co-authored-by:"
+      branch-pattern:
+        description: >
+          grep -E pattern a PR head branch must match. dependabot/*,
+          renovate/*, and next are always allowed regardless of this pattern.
+        required: false
+        type: string
+        default: "^(feature|bug|hotfix)-[1-9][0-9]*$"
+
+permissions: {}
+
+jobs:
+  commit-message:
+    name: Validate Commits
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: ⤵️ Check out code from GitHub
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: 📝 Lint commit messages
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          DISALLOWED_TRAILER_PATTERN: ${{ inputs.disallowed-trailer-pattern }}
+        run: |
+          set -euo pipefail
+
+          CONVENTIONAL_PATTERN='^(feat|fix|perf|refactor|docs|test|build|ci|style|chore|revert)(\([^)]+\))?!?: .{1,72}$'
+
+          errors=0
+          checked=0
+
+          while IFS= read -r sha; do
+            if git show -s --format='%B' "$sha" | grep -qiE "$DISALLOWED_TRAILER_PATTERN"; then
+              echo "::error::Disallowed trailer found (${sha:0:7}): remove before merging. A squash merge without an explicit --subject/--body can also reintroduce it — see runbooks/branch-protection.md."
+              errors=$((errors + 1))
+            fi
+
+            parent_count=$(git cat-file -p "$sha" | grep -c '^parent' || true)
+            [ "$parent_count" -gt 1 ] && continue
+
+            subject=$(git show -s --format='%s' "$sha")
+            checked=$((checked + 1))
+
+            if ! echo "$subject" | grep -qE "$CONVENTIONAL_PATTERN"; then
+              echo "::error::Invalid commit message (${sha:0:7}): expected type(scope): description <=72 chars"
+              errors=$((errors + 1))
+            fi
+          done < <(git log --format='%H' "${BASE_SHA}..${HEAD_SHA}")
+
+          if [ "$errors" -gt 0 ]; then
+            echo "::error::$errors commit(s) failed validation — run: git rebase -i ${BASE_SHA}"
+            exit 1
+          fi
+
+          echo "✅ $checked commit(s) validated"
+
+  pr-title:
+    name: Validate PR Title
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: 📋 Check PR title follows Conventional Commits
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          PATTERN='^(feat|fix|perf|refactor|docs|test|build|ci|style|chore|revert)(\([^)]+\))?!?: .{1,72}$'
+          if ! echo "$PR_TITLE" | grep -qE "$PATTERN"; then
+            echo "::error::PR title must follow Conventional Commits: type(scope): description"
+            exit 1
+          fi
+          echo "✅ PR title valid"
+
+  branch-naming:
+    name: Validate Branch Name
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: 🌿 Check branch naming convention
+        env:
+          BRANCH: ${{ github.head_ref }}
+          BRANCH_PATTERN: ${{ inputs.branch-pattern }}
+        run: |
+          if echo "$BRANCH" | grep -qE '^(dependabot|renovate)/' || \
+             [ "$BRANCH" = "next" ]; then
+            echo "✅ OK"
+            exit 0
+          fi
+          if ! echo "$BRANCH" | grep -qE "$BRANCH_PATTERN"; then
+            echo "::error::Branch name must match ${BRANCH_PATTERN} (see decisions/0008-branching-model.md)"
+            exit 1
+          fi
+          echo "✅ Branch name valid"

--- a/.github/workflows/lint-commits.yml
+++ b/.github/workflows/lint-commits.yml
@@ -1,0 +1,17 @@
+---
+name: Lint Commits
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  commit-lint:
+    uses: ./.github/workflows/commit-lint.yml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@ When working in z-shell repositories, optimize for:
 - **Plugin authoring:** read the canonical [Zsh Plugin Standard](https://wiki.zshell.dev/community/zsh_plugin_standard) for plugin creation, code changes, reviews, templates, and documentation. Official Zsh documentation remains authoritative for shell semantics; manager-specific profiles are optional.
 - **Canonical plugin manager:** `zi`. See `decisions/0002-zi-as-canonical-plugin-manager.md`.
 - **Commits and PR titles:** Conventional Commits. See `decisions/0003-conventional-commits.md`.
-- **Commit trailers:** Never include a `Co-authored-by` trailer. This organization-wide ban is author-enforced until [z-shell/.github#464](https://github.com/z-shell/.github/issues/464) lands.
+- **Commit trailers:** Never include a `Co-authored-by` trailer. CI-enforced on `z-shell/.github` via `commit-lint.yml`; org-wide rollout to other repositories is tracked in [z-shell/.github#464](https://github.com/z-shell/.github/issues/464), still author-enforced there until each repo adds the caller.
 - **Branch selection:** Follow `decisions/0008-branching-model.md` and verify the live state of the owning repository; do not assume one universal default branch.
 - **Documentation placement:** keep long-form docs in the wiki when practical; keep repo-local docs focused on policy, workflow, and source-adjacent guidance.
 - **Workflow files:** follow the org workflow conventions and keep permissions explicit, actions pinned, and concurrency defined.

--- a/runbooks/onboarding.md
+++ b/runbooks/onboarding.md
@@ -46,9 +46,13 @@ Grant only what the role requires; record the grant:
 - Clone the owning repository directly. Separate multi-repository tooling is
   optional and outside this public runbook.
 - Configure commit signing: commits are signed (`gpg.format=ssh`); set a
-  `user.signingkey`. Never add a `Co-authored-by` trailer — this is org policy,
-  and note that no default-branch CI currently enforces it, so it is the
-  author's responsibility, not a gate that will catch a mistake.
+  `user.signingkey`. Never add a `Co-authored-by` trailer — this is org policy.
+  `z-shell/.github` enforces it in CI (`commit-lint.yml`, PRs into `main`);
+  most other repositories do not have the caller wired in yet
+  ([z-shell/.github#464](https://github.com/z-shell/.github/issues/464)), so
+  it remains the author's responsibility there — including watching for a
+  squash merge silently reintroducing the trailer even when no individual
+  commit had one (`runbooks/branch-protection.md`).
 - Follow Conventional Commits and the branch model for the repo's class
   (ADR-0008).
 


### PR DESCRIPTION
## Summary

Promotes `z-shell/zi`'s `next`-branch-only `commit-lint.yml` into a reusable `workflow_call` workflow and wires it in on **this repository's own** PRs into `main` — where the incident that exposed the gap just happened (a GitHub-synthesized `Co-authored-by` trailer surviving the ADR-0016 acceptance squash merge, #516).

## Why now

`#464` proposed exactly this but was closed by #468, which corrected the docs to admit enforcement didn't exist rather than building it. The gap it described is still real — it just resurfaced concretely last night. Reopening #464 separately to track the org-wide rollout to other repos; this PR is the first real caller.

## What changed

- `.github/workflows/commit-lint.yml` — reusable: disallowed-trailer + Conventional Commits on commits, PR-title check, branch-naming check. Same three jobs as `zi`'s version, with the trailer pattern and branch pattern exposed as `workflow_call` inputs.
- `.github/workflows/lint-commits.yml` — thin local caller (`uses: ./.github/workflows/commit-lint.yml`), `pull_request` into `main`.
- `AGENTS.md`, `runbooks/onboarding.md` — both said the ban was author-enforced everywhere; now accurate for this repo, still true for the rest of the org pending #464's rollout.

## Note on the blocker #464 flagged

Its body cites a conflict between `commit-lint.yml`'s branch-naming regex and `AGENTS.md`'s `feature-<id>` convention. Checked `zi`'s live `next` branch: that regex is already `^(feature|bug|hotfix)-[1-9][0-9]*$`, matching ADR-0008. The conflict described no longer exists — must have been fixed after #464 was filed without updating the issue text.

## Verification

- `python3 -m unittest scripts.test_validate_agent_policy` — 74 passed.
- Both new workflow files parse as valid YAML; prettier-clean.
- This PR's own branch (`feature-464`) and title were picked to satisfy the new checks — first real test of them.

Refs #464