### PR TITLE
docs(labels): record sync scope and define an approved unknown-label sweep

### DIFF
--- a/runbooks/labels.md
+++ b/runbooks/labels.md
@@ -2,6 +2,28 @@
 
 Use this runbook when cleaning or syncing labels across z-shell repositories.
 
+## Sync scope
+
+Canonical label sync targets **active, public, non-fork** repositories only.
+`scripts/labels-sync.rb --all-repos` audits every repository the token can see,
+so its raw output is wider than the sync scope. Filter before reading drift
+totals, or private and fork repositories will keep reporting as regressions
+when they are simply out of scope.
+
+Excluded, and why:
+
+- **Private repositories.** Not part of the public contributor-facing label
+  surface. Currently `z-shell/.github-private` and `z-shell/.trunk`.
+- **Forks.** Their label sets largely belong to the upstream project, and
+  rewriting them loses that provenance without benefiting z-shell contributors.
+- **Archived repositories.** Read-only by definition.
+
+The exclusion is deliberate, not a backlog. Do not treat drift in these
+repositories as a finding, and do not include them in org-wide totals without
+saying which scope the number uses. If a repository leaves fork or private
+status and becomes an active public repository, it enters scope at that point
+and should be synced like any other.
+
 ## Source of truth
 
 `lib/labels.yml` is the canonical organization label set.

--- a/runbooks/labels.md
+++ b/runbooks/labels.md
@@ -138,6 +138,47 @@ Also retire spaced namespace variants such as `type: bug`, `area: docs`, `priori
 
 Do not delete unknown labels in bulk. If a repository has a local label that is not obviously legacy, open or update an issue before removing it.
 
+`labels-sync.rb` enforces this: `sync_policy.delete_unknown_labels` is `false`
+and the script never deletes an unknown label. Leave that setting alone. An
+approved sweep is a one-off operation, not a reason to make deletion the
+default.
+
+### Exception: an approved unknown-label sweep
+
+The prohibition above is the default and stays the default. A bulk deletion is
+permitted only as a separately approved operation that meets every condition
+below. Missing any one of them means the sweep does not proceed.
+
+1. **Explicit maintainer approval**, given against figures measured at approval
+   time rather than against an earlier report.
+2. **Usage measured live from `repos/OWNER/REPO/issues?state=all`**, counting
+   items in every state. Never use the issue search API: its index lags bulk
+   label changes badly enough to report labels as in use months after they were
+   removed, and it fails in both directions.
+3. **Delete only definitions attached to zero items.** A label carrying even one
+   item is migrated or left alone, never deleted.
+4. **Preserve anything referenced by configuration**, verified by reading the
+   files rather than assuming. At minimum check `.github/labeler.yml` and the
+   `stale-*-label` and `exempt-*-labels` inputs of any stale or lock workflow.
+   Deleting a referenced label does not fail loudly; `actions/labeler` recreates
+   it on the next matching pull request, so the sweep quietly undoes itself.
+5. **Archive every label definition** in the affected repositories, including
+   color and description, before the first write, so any deletion is
+   restorable.
+6. **Pilot on one low-traffic repository** and verify it by hand before the
+   remaining repositories.
+7. **Batch per repository with per-operation logging**, so a failure is
+   contained and attributable.
+8. **Re-audit afterwards and re-derive the justification for every survivor**,
+   rather than trusting the plan that was executed.
+
+Record the result on the owning issue, including the counts before and after
+and the exclusion list actually applied.
+
+The 2026-08-19 sweep is the reference execution: 1,483 unknown definitions
+across the 86 in-scope repositories reduced to 93, with 1,390 deleted and every
+survivor re-verified as in use or configuration-referenced.
+
 ## Label sync script
 
 `scripts/labels-sync.rb` is the canonical entrypoint. The older `scripts/labels-dry-run.rb` name remains as a compatibility wrapper for existing local commands, but new runbook examples should use `scripts/labels-sync.rb`.


### PR DESCRIPTION
Two gaps in `runbooks/labels.md` surfaced by the 2026-08-19 label audit.

## 1. Sync scope was never written down

`labels-sync.rb --all-repos` audits every repository the token can see, which is wider than what canonical sync actually targets. The result is that private and fork repositories report as drift forever and inflate org-wide totals.

Measured on 2026-08-19: 93 repositories audited, 86 active/public/non-fork. The other 7 accounted for 215 missing canonical labels and 116 legacy labels, all of it out of scope rather than regression.

This records the scope, names each exclusion with its reason, and states that a repository entering active public non-fork status enters scope at that point.

## 2. The bulk-delete prohibition had already been overridden

The runbook said "Do not delete unknown labels in bulk" with no exception path. A maintainer-approved sweep on 2026-08-19 deleted 1,390 unused unknown definitions across the 86 in-scope repositories, taking unknown labels from 1,483 to 93.

Rather than weaken the rule to match what happened, this keeps the prohibition as the default and documents the conditions an approved sweep must meet, so the next one is done safely instead of improvised:

- approval given against figures measured at approval time;
- usage read live from `issues?state=all`, never the search API, whose index lagged the May bulk changes badly enough to report 52 phantom items for a label attached to nothing;
- deletion limited to definitions attached to zero items;
- configuration-referenced labels preserved, verified by reading `labeler.yml` and stale/lock workflow inputs;
- a restorable archive of every label definition before the first write;
- a hand-verified pilot repository;
- per-repository batching with per-operation logging;
- a post-run re-derivation of every survivor.

It also states that `sync_policy.delete_unknown_labels` stays `false`, so an approved one-off never becomes the default.

## Why condition 4 is load-bearing

Deleting a configuration-referenced label does not fail loudly. `actions/labeler` applies labels through the issues API, which creates a missing label rather than erroring, so the sweep quietly undoes itself on the next matching pull request. That is not hypothetical: it is why `enhancement ✨` reappeared in `z-shell/zi` after #467 deleted it. Tracked separately in #527.

## Verification

Documentation only, no executable change. Scope and figures were verified against live audit output rather than the earlier report; the sweep result was re-audited org-wide with every one of the 93 survivors re-derived as in-use or configuration-referenced, and zero unjustified leftovers.

Related: #467, #524, #527