### PR TITLE
fix: use GraphQL ids in project reconciliation

### DIFF
--- a/.github/workflows/project-reconcile.yml
+++ b/.github/workflows/project-reconcile.yml
@@ -63,15 +63,15 @@ jobs:
                       nodes {
                         id
                         content {
-                          ... on Issue { url node_id title repository { nameWithOwner } }
-                          ... on PullRequest { url node_id title repository { nameWithOwner } }
+                          ... on Issue { url id title repository { nameWithOwner } }
+                          ... on PullRequest { url id title repository { nameWithOwner } }
                         }
                       }
                     }
                   }
                 }
               }' -f project="${project_id}" -f cursor="${cursor}")"
-            jq -c '.data.node.items.nodes[] | select(.content != null) | {item_id: .id, url: .content.url, node_id: .content.node_id, title: .content.title, repository: .content.repository.nameWithOwner}' <<<"${response}" >> project-items.ndjson
+            jq -c '.data.node.items.nodes[] | select(.content != null) | {item_id: .id, url: .content.url, node_id: .content.id, title: .content.title, repository: .content.repository.nameWithOwner}' <<<"${response}" >> project-items.ndjson
             if [[ "$(jq -r '.data.node.items.pageInfo.hasNextPage' <<<"${response}")" != 'true' ]]; then
               break
             fi


### PR DESCRIPTION
## Summary
- fix the Project 28 reconciliation query to use GraphQL's `id` field
- preserve the existing read-only-by-default and explicit apply gate

## Root cause
The first reconciliation run failed because `node_id` is a REST field and is not available on GraphQL `Issue` or `PullRequest` objects.

## Verification
- corrected selection validated against live Project 28 GraphQL data
- YAML parsing passed
- `scripts/validate-agent-policy.py` passed
- `git diff --check` passed

Related run: https://github.com/z-shell/.github/actions/runs/32310759276
