### PR TITLE
feat(project): reconcile Delivery work management

### DIFF
--- a/.github/AGENT_MEMORY.md
+++ b/.github/AGENT_MEMORY.md
@@ -20,7 +20,8 @@ Before starting non-trivial work:
 1. Search the owning repository for open issues and pull requests related to the task.
 2. Check linked tracker items and previous handoff comments.
 3. Prefer the most recent GitHub-visible state over local notes or LLM memory.
-4. If no issue exists for planned or deferred work, create one in the owning repository.
+4. If no issue exists for planned or deferred work, propose one. Create it only
+   when explicit external-write authority is present.
 5. Verify the owning issue is visible in Z-shell Delivery before substantive
    implementation starts. If it is missing, restore membership or record the
    blocker on the issue.

--- a/.github/AGENT_MEMORY.md
+++ b/.github/AGENT_MEMORY.md
@@ -19,12 +19,17 @@ Before starting non-trivial work:
 2. Check linked tracker items and previous handoff comments.
 3. Prefer the most recent GitHub-visible state over local notes or LLM memory.
 4. If no issue exists for planned or deferred work, create one in the owning repository.
+5. Verify the owning issue is visible in Z-shell Delivery before substantive
+   implementation starts. If it is missing, restore membership or record the
+   blocker on the issue.
 
 While working:
 
 1. Keep progress attached to the relevant issue or pull request.
 2. Update the thread when status changes materially, especially when work becomes blocked.
 3. Link branches, pull requests, CI runs, and follow-up issues instead of relying on prose-only status.
+4. Record a next action or blocker for active work. Assignment alone does not
+   represent managed progress.
 
 Before stopping or handing off:
 

--- a/.github/workflows/project-reconcile.yml
+++ b/.github/workflows/project-reconcile.yml
@@ -24,10 +24,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      - name: Check out reconciliation source
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
       - name: Reconcile organization issues
         env:
           GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
-          APPLY: ${{ inputs.apply || false }}
+          APPLY: ${{ github.event_name == 'schedule' || inputs.apply || false }}
           ORGANIZATION: z-shell
           PROJECT_NUMBER: '28'
         run: |
@@ -48,7 +51,7 @@ jobs:
           gh api --paginate \
             -H 'Accept: application/vnd.github+json' \
             "/search/issues?q=org%3A${ORGANIZATION}%20is%3Aissue%20is%3Aopen&per_page=100" \
-            --jq '.items[] | {url: .html_url, node_id: .node_id, title: .title, repository: .repository_url, author: .user.login, labels: [.labels[].name]}' \
+            --jq '.items[] | {url: .html_url, node_id: .node_id, title: .title, repository: .repository_url, author: .user.login, updated_at: .updated_at, labels: [.labels[].name]}' \
             > open-issues.ndjson
 
           : > project-items.ndjson
@@ -78,33 +81,11 @@ jobs:
             cursor="$(jq -r '.data.node.items.pageInfo.endCursor' <<<"${response}")"
           done
 
-          python3 - <<'PY'
-          import json
-          from pathlib import Path
-
-          def read_ndjson(name):
-              path = Path(name)
-              return [json.loads(line) for line in path.read_text().splitlines() if line]
-
-          issues = read_ndjson('open-issues.ndjson')
-          items = read_ndjson('project-items.ndjson')
-          item_nodes = {item['node_id'] for item in items}
-          missing = [issue for issue in issues if issue['node_id'] not in item_nodes]
-          report = {
-              'organization': 'z-shell',
-              'project_number': 28,
-              'apply_requested': '${{ inputs.apply || false }}' == 'true',
-              'open_issue_count': len(issues),
-              'project_content_count': len(items),
-              'missing_open_issues': missing,
-          }
-          Path('project-reconcile-report.json').write_text(json.dumps(report, indent=2) + '\n')
-          print(json.dumps({
-              'open_issue_count': len(issues),
-              'project_content_count': len(items),
-              'missing_open_issue_count': len(missing),
-          }, indent=2))
-          PY
+          python3 scripts/project_reconcile.py \
+            --open-issues open-issues.ndjson \
+            --project-items project-items.ndjson \
+            --output project-reconcile-report.json \
+            --stale-after-days 5
 
           if [[ "${APPLY}" != 'true' ]]; then
             echo 'Dry run only; no project mutations requested.'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,8 @@ When working in z-shell repositories, optimize for:
 4. Read the relevant ADRs, patterns, and runbooks.
 5. For cross-repo questions, search the organization before assuming the local repo is unique.
 6. If no issue exists for non-trivial planned work, create one in the owning repository.
+7. For substantive work, verify that the owning issue is in Z-shell Delivery
+   (Project 28), with its triage state visible before implementation starts.
 
 ## While editing
 
@@ -91,6 +93,9 @@ When working in z-shell repositories, optimize for:
 - Keep changes reviewable and scoped; separate mechanical cleanup from behavioral change.
 - Update nearby docs, templates, or runbooks when your change makes them inaccurate.
 - Avoid creating a second conflicting source of truth. Extend the canonical file instead.
+- Record material progress, blockers, review readiness, and handoff on the
+  owning issue or pull request. Assignment alone is not evidence of active
+  management.
 
 ## Before claiming done
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,9 +85,12 @@ When working in z-shell repositories, optimize for:
 3. Check linked tracker items and previous handoff comments.
 4. Read the relevant ADRs, patterns, and runbooks.
 5. For cross-repo questions, search the organization before assuming the local repo is unique.
-6. If no issue exists for non-trivial planned work, create one in the owning repository.
+6. If no issue exists for non-trivial planned work, propose one. Create it only
+   when explicit external-write authority is present.
 7. For substantive work, verify that the owning issue is in Z-shell Delivery
    (Project 28), with its triage state visible before implementation starts.
+
+Creating or updating issues, comments, pull requests, or tracker records requires explicit external-write authority. Without that authority, report the proposed external write instead.
 
 ## While editing
 

--- a/runbooks/project-tracker.md
+++ b/runbooks/project-tracker.md
@@ -50,29 +50,52 @@ its filter language cannot exclude bot authors and the GitHub Free plan allows
 only one auto-add workflow. Keep it narrow while the central reconciler is
 introduced.
 
-The staged reconciler is read-only by default. It uses a project-scoped
-credential supplied as `PROJECT_TOKEN` and accepts an explicit `apply=true`
-manual dispatch only after review. It must be idempotent, emit a drift report,
-and never overwrite human-set field values without a documented rule.
+The scheduled reconciler uses a project-scoped credential supplied as
+`PROJECT_TOKEN` to add every missing open organization issue to Project 28. It
+is additive and idempotent, emits a drift report, and never overwrites
+human-set field values. Manual dispatch remains read-only unless a maintainer
+sets `apply=true` after reviewing the report.
 
 The target implementation is an organization-owned GitHub App with Project
 read/write permission, installed on all repositories, receiving only the
 required issue, pull-request, repository, and installation events. A scheduled
 reconciliation remains as recovery for missed webhook deliveries.
 
+## Managed progress
+
+Project membership prevents work from disappearing. It does not prove that work
+is managed. Every substantive task must have an owning issue, visible Project
+28 triage state, and material progress recorded on its issue or pull request.
+Record a next action or blocker when work starts, becomes blocked, is ready for
+review, or is handed off. Assignment alone is not active management.
+
+The reconciliation artifact lists `stale_open_issues`: open issues without an
+update for five days. Items labeled `status:blocked` are excluded so that the
+blocked workflow remains explicit. This is a review queue only. It must never
+automatically comment, label, close, or otherwise mutate an issue.
+
+At least weekly, review missing, stale, blocked, and untriaged work. Resolve
+each candidate by recording a next action, blocker, deferral, or closure, then
+publish a Project status update that states portfolio health and material risks.
+Configure Project 28's built-in workflows to set new items to `Todo` and closed
+issues or merged pull requests to `Done`. Archive completed items only after
+the agreed retention period.
+
 ## Verification
 
-Run the dry-run workflow manually and inspect its artifact before enabling any
-write mode. The report must identify:
+Run the workflow manually without `apply=true` and inspect its artifact before
+changing reconciliation behavior. The report must identify:
 
 - open organization issues missing from Project 28
 - project items whose source issue or pull request is no longer visible
 - unclassified workstream records
 - bot and dependency-dashboard records
 - project items with conflicting or missing relationship data
+- open issues that have been stale for five days, excluding `status:blocked`
 
 Any project membership, field, label, issue, repository, organization setting,
-or workflow-setting mutation still requires explicit maintainer approval.
+or workflow-setting mutation outside the scheduled additive reconciliation still
+requires explicit maintainer approval.
 
 ## See also
 

--- a/scripts/project_reconcile.py
+++ b/scripts/project_reconcile.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Build a deterministic GitHub Project reconciliation report from NDJSON."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+
+def parse_timestamp(value: object, *, field: str) -> datetime:
+    if not isinstance(value, str):
+        raise ValueError(f"{field} must be an ISO 8601 timestamp")
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(UTC)
+    except ValueError as error:
+        raise ValueError(f"{field} must be an ISO 8601 timestamp") from error
+
+
+def read_ndjson(path: Path) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for line_number, line in enumerate(path.read_text().splitlines(), start=1):
+        if not line:
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError as error:
+            raise ValueError(f"{path}:{line_number}: invalid JSON") from error
+        if not isinstance(record, dict):
+            raise ValueError(f"{path}:{line_number}: record must be an object")
+        records.append(record)
+    return records
+
+
+def issue_sort_key(issue: dict[str, Any]) -> str:
+    url = issue.get("url")
+    if not isinstance(url, str):
+        raise ValueError("issue url must be a string")
+    return url
+
+
+def build_report(
+    open_issues_path: Path,
+    project_items_path: Path,
+    *,
+    now: str,
+    stale_after_days: int,
+) -> dict[str, Any]:
+    if stale_after_days < 1:
+        raise ValueError("stale_after_days must be at least one")
+
+    open_issues = read_ndjson(open_issues_path)
+    project_items = read_ndjson(project_items_path)
+    project_node_ids = {
+        item["node_id"]
+        for item in project_items
+        if isinstance(item.get("node_id"), str)
+    }
+    cutoff = parse_timestamp(now, field="now") - timedelta(days=stale_after_days)
+
+    missing_open_issues: list[dict[str, Any]] = []
+    stale_open_issues: list[dict[str, Any]] = []
+    for issue in open_issues:
+        node_id = issue.get("node_id")
+        if not isinstance(node_id, str):
+            raise ValueError("issue node_id must be a string")
+        updated_at = parse_timestamp(issue.get("updated_at"), field="issue updated_at")
+        labels = issue.get("labels")
+        if not isinstance(labels, list) or not all(isinstance(label, str) for label in labels):
+            raise ValueError("issue labels must be a list of strings")
+        issue_sort_key(issue)
+        if node_id not in project_node_ids:
+            missing_open_issues.append(issue)
+        if updated_at < cutoff and "status:blocked" not in labels:
+            stale_open_issues.append(issue)
+
+    missing_open_issues.sort(key=issue_sort_key)
+    stale_open_issues.sort(key=issue_sort_key)
+    return {
+        "schema": "z-shell/project-reconcile-report/v2",
+        "open_issue_count": len(open_issues),
+        "project_content_count": len(project_items),
+        "missing_open_issues": missing_open_issues,
+        "stale_open_issues": stale_open_issues,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--open-issues", type=Path, required=True)
+    parser.add_argument("--project-items", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--now", default=datetime.now(UTC).isoformat())
+    parser.add_argument("--stale-after-days", type=int, default=5)
+    arguments = parser.parse_args()
+
+    report = build_report(
+        arguments.open_issues,
+        arguments.project_items,
+        now=arguments.now,
+        stale_after_days=arguments.stale_after_days,
+    )
+    arguments.output.write_text(json.dumps(report, indent=2) + "\n")
+    print(
+        json.dumps(
+            {
+                "open_issue_count": report["open_issue_count"],
+                "project_content_count": report["project_content_count"],
+                "missing_open_issue_count": len(report["missing_open_issues"]),
+                "stale_open_issue_count": len(report["stale_open_issues"]),
+            },
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_project_reconcile.py
+++ b/scripts/test_project_reconcile.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Tests for the Project 28 reconciliation report generator."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import project_reconcile
+
+
+class ProjectReconcileTest(unittest.TestCase):
+    def write_ndjson(self, directory: Path, name: str, records: list[dict[str, object]]) -> Path:
+        path = directory / name
+        path.write_text("".join(json.dumps(record) + "\n" for record in records))
+        return path
+
+    def test_report_identifies_missing_and_stale_open_issues(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            directory = Path(temporary_directory)
+            open_issues = self.write_ndjson(
+                directory,
+                "open-issues.ndjson",
+                [
+                    {
+                        "url": "https://github.com/z-shell/example/issues/3",
+                        "node_id": "issue-3",
+                        "updated_at": "2026-08-10T00:00:00Z",
+                        "labels": [],
+                    },
+                    {
+                        "url": "https://github.com/z-shell/example/issues/2",
+                        "node_id": "issue-2",
+                        "updated_at": "2026-08-20T00:00:00Z",
+                        "labels": [],
+                    },
+                    {
+                        "url": "https://github.com/z-shell/example/issues/1",
+                        "node_id": "issue-1",
+                        "updated_at": "2026-08-01T00:00:00Z",
+                        "labels": ["status:blocked"],
+                    },
+                ],
+            )
+            project_items = self.write_ndjson(
+                directory,
+                "project-items.ndjson",
+                [{"node_id": "issue-2"}],
+            )
+
+            report = project_reconcile.build_report(
+                open_issues,
+                project_items,
+                now="2026-08-21T00:00:00Z",
+                stale_after_days=5,
+            )
+
+        self.assertEqual(3, report["open_issue_count"])
+        self.assertEqual(1, report["project_content_count"])
+        self.assertEqual(
+            [
+                "https://github.com/z-shell/example/issues/1",
+                "https://github.com/z-shell/example/issues/3",
+            ],
+            [issue["url"] for issue in report["missing_open_issues"]],
+        )
+        self.assertEqual(
+            ["https://github.com/z-shell/example/issues/3"],
+            [issue["url"] for issue in report["stale_open_issues"]],
+        )
+
+    def test_report_rejects_issue_without_updated_timestamp(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            directory = Path(temporary_directory)
+            open_issues = self.write_ndjson(
+                directory,
+                "open-issues.ndjson",
+                [{"url": "https://github.com/z-shell/example/issues/1", "node_id": "issue-1", "labels": []}],
+            )
+            project_items = self.write_ndjson(directory, "project-items.ndjson", [])
+
+            with self.assertRaisesRegex(ValueError, "updated_at"):
+                project_reconcile.build_report(
+                    open_issues,
+                    project_items,
+                    now="2026-08-21T00:00:00Z",
+                    stale_after_days=5,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #534

## Summary

- reconcile every open organization issue into Z-shell Delivery on scheduled runs
- report five-day stale work, excluding explicit blocked items
- require Project membership and durable material-progress evidence for substantive work

## Verification

- `python3 scripts/test_project_reconcile.py`
- `python3 -m py_compile scripts/project_reconcile.py scripts/test_project_reconcile.py`
- YAML parsing and `actionlint .github/workflows/project-reconcile.yml`
- `git diff --check`
- `python3 scripts/test_validate_agent_policy.py`