### PR TITLE
docs(triage): allow authorized agent labeling

### DIFF
--- a/runbooks/triage.md
+++ b/runbooks/triage.md
@@ -2,7 +2,9 @@
 
 How to classify, prioritize, and respond to issues and pull requests across the z-shell organization.
 
-**Hard rule:** LLM agents draft; humans apply labels, post comments, and close items.
+**Hard rule:** LLM agents may apply canonical labels when a maintainer
+explicitly authorizes the specific triage scope. Otherwise, agents draft label
+changes. Humans post comments and close items.
 
 ## When triage happens
 


### PR DESCRIPTION
## Summary

- allow LLM agents to apply canonical labels when a maintainer explicitly authorizes the triage scope
- keep label changes draft-only without that authorization
- keep comments and issue closures human-only
- preserve the stricter draft-only boundary for unattended recurring reviews

## Instruction impact review

1. **Classification:** This is scoped operational policy for interactive issue and pull-request triage.
2. **Consumers and contexts:** All supported agent runtimes performing the `triage` task across z-shell repositories consume this runbook through the public instruction manifest.
3. **Canonical owner:** `runbooks/triage.md` remains the correct canonical owner.
4. **Duplication or contradiction:** No duplicate owner is introduced. `runbooks/recurring-operations.md` intentionally remains stricter for unattended and recurring reviews.
5. **Manifest impact:** No manifest route needs to change because the existing required `runbook-triage` surface and `triage` task routing remain correct.
6. **Runtime delivery:** Every supported runtime continues to receive the rule through the required public manifest route; no optional hook, skill, or adapter becomes authoritative.
7. **Generated output and limits:** The public baseline and private overlay are unchanged, so no generated `AGENTS.md` update is part of this repository change. Private meta-workspace gitlink and composite reconciliation remains a separate post-merge change.

## Validation

- `python3 scripts/validate-agent-policy.py`: passed
- `python3 -m unittest scripts/test_validate_agent_policy.py -v`: 75 tests passed
- `git diff --check`: passed

No issue comments, closures, labels, repository settings, or automation behavior are changed by this pull request.