### PR TITLE
docs(security): prefer private vulnerability reports

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -2,16 +2,28 @@
 
 ## Reporting a Vulnerability
 
-If there are any vulnerabilities in [Z-Shell](https://github.com/z-shell) organization repositories, don't hesitate to _report them_.
+Please report vulnerabilities in Z-Shell repositories privately:
 
-1. Use any of the contact options listed on [GitHub organization profile](https://github.com/z-shell).
-2. Describe the vulnerability so we can evaluate it faster.
-3. If necessary, release a fix or mitigating steps to address it. We will contact you to let you know the outcome and will credit you in the report.
-4. You are free to disclose the vulnerability publicly once we have either:
-   - published a fix
-   - declined to address the vulnerability for whatever reason
+1. Open the affected repository's **Security** tab.
+2. Select **Report a vulnerability** to start a private GitHub Security
+   Advisory.
+3. Include the affected repository and version or revision, the expected
+   impact, and enough reproduction details for maintainers to evaluate the
+   report. If you have a proposed fix, include or summarize it.
 
-> **Note**
->
-> - Please **do not disclose the vulnerability publicly** until a fix is released.
-> - If you have a fix, that is most welcome -- **please attach or summarize it in your message**!
+If **Report a vulnerability** is unavailable, use a private contact method on
+the [Z-Shell organization profile](https://github.com/z-shell). Do not include
+vulnerability details in a public issue, pull request, or discussion.
+
+## Response and Coordinated Disclosure
+
+Maintainers will evaluate the report, coordinate any fix or mitigation, and
+keep the reporter informed. We will credit the reporter in the published record
+unless they request anonymity.
+
+Please do not disclose the vulnerability publicly until a fix is published or
+the report is declined. Coordinate disclosure timing with the incident owner.
+
+Maintainers follow the
+[security incident response runbook](https://github.com/z-shell/.github/blob/main/runbooks/security-incident-response.md)
+for triage, remediation, disclosure, and post-incident review.


### PR DESCRIPTION
## Problem

z-shell/zi#315 reports a missing repository security policy. Zi already inherits the organization policy from this repository, so adding a second Zi-local copy would create policy drift. The inherited policy still routes reporters to generic organization contacts instead of the enabled private vulnerability-reporting flow.

## Approach

- make the affected repository's private **Report a vulnerability** flow the primary intake path
- keep organization-profile private contacts as the fallback
- explicitly prohibit vulnerability details in public issues, pull requests, or discussions
- retain coordinated-disclosure and reporter-credit expectations
- link maintainers to the canonical incident-response runbook

## Verification

- `python3 scripts/validate-agent-policy.py`
- `python3 -m unittest scripts/test_validate_agent_policy.py -v` — 75 passed
- `npx --yes markdownlint-cli2 .github/SECURITY.md` — 0 issues
- `lychee .github/SECURITY.md` — 2 links checked, 0 errors
- `actionlint .github/workflows/*.yml`
- `git diff --check`
- confirmed `z-shell/zi/security/policy` currently inherits this organization file
- confirmed private vulnerability reporting is enabled for `z-shell/zi`

## Scope and risk

This updates the single organization-level reporter policy; it does not add per-repository copies, change repository settings, or alter the internal incident-response process.

Closes z-shell/zi#315
