### PR TITLE
docs(runbooks): record priority band definitions in triage

### DIFF
--- a/runbooks/triage.md
+++ b/runbooks/triage.md
@@ -71,6 +71,19 @@ The organization label set in `lib/labels.yml` is the source of truth. Apply at 
 | duplicate              | `duplicate`        |
 | not planned            | `wontfix`          |
 
+### Priority definitions
+
+Apply `priority:high` only for the top two bands. Everything below is tracked by
+project-board `Priority` rather than by a label.
+
+| Priority     | Meaning                                                                    |
+| ------------ | -------------------------------------------------------------------------- |
+| **Critical** | Data loss, security vulnerability, or complete breakage with no workaround |
+| **High**     | Significantly impacts users or blocks important work; schedule next        |
+| **Medium**   | Important but not urgent; prioritize against other planned work            |
+| **Low**      | Nice to have; no fixed timeline                                            |
+| **None**     | Not yet triaged or genuinely optional                                      |
+
 ## Step 3 — Cross-reference
 
 Before responding:


### PR DESCRIPTION
## Summary

Records the priority band definitions in the triage runbook.

The public wiki carried a priority definition table that no runbook duplicated. Removing maintainer content from the wiki per [ADR 0006](https://github.com/z-shell/.github/blob/main/decisions/0006-wiki-content-root-boundaries.md) would have dropped it, so it lands here, next to the triage classification tables that already exist.

## Why here

`runbooks/triage.md` already owns the label classification tables and the Project 28 field-setting procedure. Priority semantics belong with them rather than on a public contributor-facing page.

Also notes that `priority:high` covers only the top two bands, since the label set has no `priority:critical` and the distinction was previously implicit.

## Related

Paired with z-shell/wiki#871 which removes the maintainer-only surface from the public wiki. That PR links back to this runbook, so merging this one first avoids a dangling reference.

## Verification

- `lib/labels.yml` still parses
- No column mismatches in the modified markdown tables
- Additive only: no existing runbook content changed
