### PR TITLE
fix(ci): exclude intentional README template placeholders

### DIFF
--- a/.github/lychee.toml
+++ b/.github/lychee.toml
@@ -85,7 +85,15 @@ method = "get"
 #glob_ignore_case = false
 
 # Exclude URLs and mail addresses from checking (supports regex).
-exclude = ['/z-shell/.github/actions', '/daweedkob', '/tondrejk']
+# The README template placeholders resolve only after the template is copied
+# into its owning repository. Keep the rest of that template under link checks.
+exclude = [
+  '/z-shell/.github/actions',
+  '/daweedkob',
+  '/tondrejk',
+  'github\.com/z-shell/%3Crepository%3E',
+  'templates/readme/(?:LICENSE|repository-owned-asset-path)$',
+]
 
 # Exclude these filesystem paths from getting checked.
 #exclude_path = ["clip"]

--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -10,12 +10,14 @@ on:
   push:
     branches: [main]
     paths:
+      - ".github/lychee.toml"
       - "**.md"
       - "**.mdx"
       - "**.html"
   pull_request_target:
     branches: [main]
     paths:
+      - ".github/lychee.toml"
       - "**.md"
       - "**.mdx"
       - "**.html"


### PR DESCRIPTION
## Summary

- exclude only the five intentional unresolved links in the Zsh plugin README
  template
- keep the template itself and its real documentation, logo, wiki, and
  organization links under Lychee checks
- trigger the Lychee workflow when `.github/lychee.toml` changes

Closes #548
Unblocks #546 and #547 after this change reaches `main`.

## Verification

- pinned Lychee `v0.18.1` against `templates/readme/zsh-plugin.md`:
  `9 Total`, `4 OK`, `5 Excluded`, `0 Errors`
- `actionlint .github/workflows/lychee.yml`
- `trunk check .github/lychee.toml .github/workflows/lychee.yml`
- `python3 -m unittest scripts/test_validate_agent_policy.py -v`
  (83 tests passed)
- `python3 scripts/validate-agent-policy.py`
- `git diff --check`

## Scope

The exclusion patterns match the encoded `<repository>` URL placeholder and
the two template-relative destinations `LICENSE` and
`repository-owned-asset-path`. The template file is not excluded wholesale.

Because the existing workflow uses `pull_request_target` with the default base
checkout, its PR run will continue to observe the current failing `main`
configuration. The push run after merge is the authoritative confirmation that
the baseline is repaired.
