### PR TITLE
docs(project): define sub-issue hierarchy policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/07_delivery_initiative.yml
+++ b/.github/ISSUE_TEMPLATE/07_delivery_initiative.yml
@@ -1,0 +1,70 @@
+name: "Delivery initiative"
+description: >-
+  Coordinate a cross-repository outcome through native sub-issues.
+title: "[initiative]: "
+labels:
+  - "type:maintenance"
+  - "area:meta"
+  - "status:triage"
+  - "meta:initiative"
+  - "meta:org-tracked"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form only for one coordinated outcome with at least two
+        independently deliverable issues in different repositories. After
+        creating the parent, create or connect each deliverable as a native
+        sub-issue. Follow the [sub-issues runbook](https://github.com/z-shell/.github/blob/main/runbooks/sub-issues.md).
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Outcome
+      description: >-
+        State the coordinated result and who benefits when it is complete.
+      placeholder: One observable outcome, not a topic or task list.
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: >-
+        Explain why the outcome matters and why coordination is needed now.
+    validations:
+      required: true
+  - type: textarea
+    id: deliverables
+    attributes:
+      label: Expected deliverables
+      description: >-
+        Name the independently deliverable results and their owning
+        repositories. Connect their issues as native sub-issues after creating
+        this parent.
+      placeholder: |
+        - z-shell/<repo>: <deliverable>
+        - z-shell/<repo>: <deliverable>
+    validations:
+      required: true
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies and risks
+      description: >-
+        Identify known blockers or execution order. Use native issue
+        dependencies after the related issues exist.
+      placeholder: None known.
+    validations:
+      required: true
+  - type: textarea
+    id: completion
+    attributes:
+      label: Completion criteria
+      description: >-
+        State how maintainers will verify the coordinated outcome before
+        closing this parent.
+      placeholder: |
+        - [ ] Observable outcome verified
+        - [ ] Required deliverables complete or explicitly descoped
+    validations:
+      required: true

--- a/.github/instruction-surfaces.json
+++ b/.github/instruction-surfaces.json
@@ -536,6 +536,18 @@
       "canonical_for": ["project-tracking"]
     },
     {
+      "id": "runbook-sub-issues",
+      "path": "runbooks/sub-issues.md",
+      "kind": "runbook",
+      "authority": "canonical-detail",
+      "consumers": ["codex", "claude-code", "copilot", "gemini-cli", "human"],
+      "tasks": ["project-tracking", "sub-issue-management"],
+      "file_patterns": ["**"],
+      "required": true,
+      "review_owner": "z-shell maintainers",
+      "canonical_for": ["sub-issue-management"]
+    },
+    {
       "id": "runbook-recurring-operations",
       "path": "runbooks/recurring-operations.md",
       "kind": "runbook",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,9 @@ Use `runbooks/triage.md` for issue and pull-request triage and
 the first pass non-destructive and, unless a maintainer asks otherwise, produce
 drafts only.
 
+For coordinated outcomes, parent issues, sub-issues, and issue dependencies,
+follow `runbooks/sub-issues.md`.
+
 ## Security
 
 - Never print, commit, or hand off secrets, tokens, or personal data.
@@ -168,4 +171,5 @@ update it only when explicit external-write authority is present.
 - `runbooks/new-repository.md`
 - `runbooks/project-tracker.md`
 - `runbooks/release.md`
+- `runbooks/sub-issues.md`
 - `runbooks/triage.md`

--- a/lib/labels.yml
+++ b/lib/labels.yml
@@ -106,6 +106,9 @@ labels:
   - name: wontfix
     color: ffffff
     description: Acknowledged but not planned for implementation.
+  - name: meta:initiative
+    color: "5319e7"
+    description: Marks a parent issue coordinating two or more independently deliverable sub-issues.
   - name: meta:org-tracked
     color: "5319e7"
     description: Indicates this issue has cross-repository tracking implications (synced to Linear).

--- a/runbooks/labels.md
+++ b/runbooks/labels.md
@@ -35,7 +35,8 @@ Use compact namespace names:
 - `priority:high`, not `priority: high`
 - `status:triage`, not `status: triage`
 
-The org tracker auto-add label is `meta:org-tracked`.
+The org tracker auto-add label is `meta:org-tracked`. The parent-only delivery
+label is `meta:initiative`; follow `runbooks/sub-issues.md` before applying it.
 
 ## Canonical groups
 
@@ -76,6 +77,10 @@ The org tracker auto-add label is `meta:org-tracked`.
 - `invalid`
 - `duplicate`
 - `wontfix`
+
+### Coordination metadata
+
+- `meta:initiative`
 - `meta:org-tracked`
 
 ## Retire old labels
@@ -246,3 +251,4 @@ scripts/labels-sync.rb \
 - `lib/labels.yml`
 - `runbooks/triage.md`
 - `runbooks/org-review.md`
+- `runbooks/sub-issues.md`

--- a/runbooks/project-tracker.md
+++ b/runbooks/project-tracker.md
@@ -41,7 +41,8 @@ coordinated outcomes, and native issue dependencies for blockers.
 
 Keep cross-repository parent issues in `z-shell/.github` and implementation
 issues in their owning repositories. Link implementation pull requests with a
-closing keyword.
+closing keyword. Apply `meta:initiative` only to qualifying parent issues and
+follow `runbooks/sub-issues.md` for ownership, status, and closing rules.
 
 ## Automation model
 
@@ -102,4 +103,5 @@ requires explicit maintainer approval.
 - `AGENTS.md`
 - `runbooks/triage.md`
 - `runbooks/labels.md`
+- `runbooks/sub-issues.md`
 - `decisions/`

--- a/runbooks/sub-issues.md
+++ b/runbooks/sub-issues.md
@@ -1,0 +1,104 @@
+# Runbook: Parent issues and sub-issues
+
+Use this runbook to coordinate an outcome through GitHub's native parent issue,
+sub-issue, and dependency relationships. GitHub Issues remain the work records;
+Project 28 displays their delivery hierarchy and progress.
+
+## When to use a parent issue
+
+Create a parent issue only when one outcome requires at least two issues that
+can be delivered, reviewed, or descoped independently. Use an issue checklist
+for small actions that do not need their own ownership, discussion, or delivery
+record.
+
+Do not use a parent merely as a topic, label substitute, release bucket, or
+duplicate roadmap. The normal hierarchy is one parent with direct sub-issues.
+Add another level only when a separately owned outcome genuinely needs it.
+
+## Ownership and labels
+
+- Keep a parent whose required deliverables span repositories in
+  `z-shell/.github`. Use the delivery initiative issue form there.
+- Keep a parent and its sub-issues in the owning repository when the outcome is
+  repository-local.
+- Keep each implementation sub-issue in the repository that owns its change.
+- Apply `meta:initiative` to the parent only. Never apply it to a sub-issue.
+- Apply the normal work-type and area labels during triage. A cross-repository
+  parent also qualifies for `meta:org-tracked` under the tracker policy.
+
+The parent owns the coordinated outcome and its acceptance criteria. Each
+sub-issue owns one independently deliverable result, its implementation detail,
+and its pull request.
+
+## Native relationships
+
+Use GitHub's native sub-issue relationship between the parent and every
+required deliverable. Do not maintain a duplicate task-list hierarchy in the
+parent body.
+
+Use native issue dependencies only for execution order or blockers. A
+parent/sub-issue relationship expresses ownership, not ordering. When one
+sub-issue blocks another, record the dependency between those issues and apply
+the blocked workflow from `runbooks/triage.md` where appropriate.
+
+Link each implementation pull request to its own sub-issue with a closing
+keyword. A pull request should close the parent directly only when that single
+pull request completes the entire coordinated outcome.
+
+## Project 28 status
+
+Add the parent and all required sub-issues to Project 28. Set each item's own
+`Item Type`, `Impact`, `Effort`, and `Priority`; set `Target date` only for a
+real commitment.
+
+Use the parent status for the coordinated outcome:
+
+- `Triage`: the outcome, owner, or required deliverable set is not agreed.
+- `Todo`: the outcome is ready, but no required deliverable is active.
+- `In Progress`: at least one required deliverable is active.
+- `In Review`: required delivery is complete and the outcome awaits final
+  confirmation.
+- `Blocked`: a dependency prevents progress on the coordinated outcome. Also
+  apply `status:blocked` to the parent.
+- `Done`: the parent is closed under the closing rules below.
+
+A blocked sub-issue does not automatically block the parent if other required
+delivery can still progress. Keep child status on the child, and use Project
+28's `Parent issue` and `Sub-issues progress` fields for roll-up rather than
+copying progress counts into prose.
+
+## Scope changes and closing
+
+Close the parent only when every required deliverable is complete or explicitly
+descoped. Record a descoping decision and its reason on the parent and affected
+sub-issue. Keep the native relationship so the outcome's history remains
+inspectable.
+
+If a newly discovered deliverable is required for the outcome, add or create
+its issue as a sub-issue before closing the parent. Reopen the parent if a
+required deliverable reopens and the coordinated outcome is no longer complete.
+
+## Review checklist
+
+Before moving a parent out of triage, confirm that:
+
+- the issue states one outcome and its acceptance criteria;
+- it has at least two independently deliverable sub-issues;
+- cross-repository ownership follows the rules above;
+- `meta:initiative` appears only on the parent;
+- native dependencies, rather than hierarchy, represent blockers or order;
+- the parent and required sub-issues are visible in Project 28; and
+- each issue has its own next action, owner or blocker, and triage fields.
+
+Do not restructure the existing backlog merely to populate hierarchy views.
+Pilot the workflow on the next real coordinated outcome, then expand it only
+when the relationships improve ownership and progress visibility.
+
+## See also
+
+- [GitHub: Adding sub-issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/adding-sub-issues)
+- [GitHub: Parent issue and sub-issue progress fields](https://docs.github.com/en/issues/planning-and-tracking-with-projects/understanding-fields/about-parent-issue-and-sub-issue-progress-fields)
+- `AGENTS.md`
+- `runbooks/labels.md`
+- `runbooks/project-tracker.md`
+- `runbooks/triage.md`

--- a/runbooks/triage.md
+++ b/runbooks/triage.md
@@ -70,6 +70,7 @@ The organization label set in `lib/labels.yml` is the source of truth. Apply at 
 | invalid                | `invalid`          |
 | duplicate              | `duplicate`        |
 | not planned            | `wontfix`          |
+| parent initiative      | `meta:initiative`  |
 
 ### Priority definitions
 
@@ -83,6 +84,13 @@ project-board `Priority` rather than by a label.
 | **Medium**   | Important but not urgent; prioritize against other planned work            |
 | **Low**      | Nice to have; no fixed timeline                                            |
 | **None**     | Not yet triaged or genuinely optional                                      |
+
+### Parent initiatives
+
+Apply `meta:initiative` only to a parent issue that coordinates at least two
+independently deliverable issues. Do not apply it to sub-issues, ordinary
+epics, or issues that only need a checklist. Follow `runbooks/sub-issues.md`
+for ownership, native relationship, status, and closing rules.
 
 ## Step 3 — Cross-reference
 
@@ -177,3 +185,4 @@ Do not handle exploit details publicly.
 - `decisions/`
 - `runbooks/labels.md`
 - `runbooks/project-tracker.md`
+- `runbooks/sub-issues.md`

--- a/scripts/test_validate_agent_policy.py
+++ b/scripts/test_validate_agent_policy.py
@@ -1938,6 +1938,47 @@ class PublicRepositoryTests(unittest.TestCase):
             },
         )
 
+    def test_public_repository_declares_sub_issue_policy(self) -> None:
+        manifest = json.loads(
+            (PUBLIC_ROOT / ".github/instruction-surfaces.json").read_text()
+        )
+        surfaces = {item["id"]: item for item in manifest["surfaces"]}
+
+        self.assertEqual(
+            surfaces["runbook-sub-issues"],
+            {
+                "id": "runbook-sub-issues",
+                "path": "runbooks/sub-issues.md",
+                "kind": "runbook",
+                "authority": "canonical-detail",
+                "consumers": [
+                    "codex",
+                    "claude-code",
+                    "copilot",
+                    "gemini-cli",
+                    "human",
+                ],
+                "tasks": ["project-tracking", "sub-issue-management"],
+                "file_patterns": ["**"],
+                "required": True,
+                "review_owner": "z-shell maintainers",
+                "canonical_for": ["sub-issue-management"],
+            },
+        )
+
+        policy = (PUBLIC_ROOT / "AGENTS.md").read_text()
+        runbook = (PUBLIC_ROOT / "runbooks/sub-issues.md").read_text()
+        labels = (PUBLIC_ROOT / "lib/labels.yml").read_text()
+        issue_form = (
+            PUBLIC_ROOT / ".github/ISSUE_TEMPLATE/07_delivery_initiative.yml"
+        ).read_text()
+
+        self.assertIn("follow `runbooks/sub-issues.md`", policy)
+        self.assertIn("Apply `meta:initiative` to the parent only.", runbook)
+        self.assertIn("- name: meta:initiative", labels)
+        self.assertIn('  - "meta:initiative"', issue_form)
+        self.assertIn('  - "meta:org-tracked"', issue_form)
+
     def test_public_repository_routes_portable_worktree_management(self) -> None:
         manifest = json.loads(
             (PUBLIC_ROOT / ".github/instruction-surfaces.json").read_text()


### PR DESCRIPTION
## Summary

- add the canonical parent issue, sub-issue, and dependency runbook
- add the parent-only `meta:initiative` label and cross-repository initiative form
- route the runbook to all supported consumers and link it from existing policy
- add a focused repository policy contract test

## Instruction impact review

1. **Classification:** Shared organization policy with canonical-detail runbook guidance and an issue-form entry point.
2. **Consumers:** Codex, Claude Code, Copilot, Gemini CLI, humans, and public Z-shell repositories consuming the organization baseline.
3. **Canonical owner:** `z-shell/.github` remains the canonical owner.
4. **Duplication:** `runbooks/sub-issues.md` owns hierarchy rules; tracker, triage, label, and agent surfaces link to it instead of copying the procedure.
5. **Manifest routing:** The public manifest adds `runbook-sub-issues` for `project-tracking` and `sub-issue-management`. Private composite regeneration remains a later gitlink reconciliation step after this public change lands.
6. **Runtime delivery:** `AGENTS.md` links the mandatory runbook, so delivery does not depend on an optional hook, agent, or skill.
7. **Validation:** Public validators and unit tests pass; `AGENTS.md` is 11,326 bytes, below the 32,768-byte limit. Manual runtime discovery was not performed.

## Verification

- `python3 -m unittest scripts/test_validate_agent_policy.py -v` (84 passed)
- `python3 -m unittest scripts/test_validate_zsh_standard_policy.py -v` (99 passed)
- `python3 scripts/validate-zsh-standard-policy.py`
- `python3 scripts/validate-agent-policy.py`
- `sh scripts/test-labels-dry-run.sh`
- `ruby scripts/test-labeler-config-audit.rb`
- issue-form and label YAML parsing, canonical-label cross-check
- read-only label preview for `z-shell/.github` and `z-shell/zsh-lint`
- `git diff --check`

Closes #521
