### PR TITLE
fix(trunk): anchor git-diff-check at the workspace root

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -15,6 +15,14 @@ plugins:
       uri: https://github.com/trunk-io/plugins
       ref: v1.11.0
 lint:
+  definitions:
+    # This repository is consumed as a submodule, so `.git` is a file whose
+    # gitdir is relative to the superproject. Trunk's sandbox copy breaks that
+    # relative path, so anchor the command at the real workspace.
+    - name: git-diff-check
+      commands:
+        - name: lint
+          run: git -C "${workspace}" diff --check ${target}
   disabled:
     - terrascan
     - trivy


### PR DESCRIPTION
## Summary

`git-diff-check` failed on every run in this repository with:

```
fatal: not a git repository: (null)
```

Trunk copies lint targets into a sandbox directory (`/tmp/trunk-<uid>/…`) and runs the linter from there. This repository is consumed as a submodule of the Z-Shell meta-workspace, so its `.git` is a *file* containing a gitdir path relative to the superproject:

```
gitdir: ../../../.git/modules/…
```

That relative path does not resolve from the sandbox, so `git diff --check` could not find a repository and exited 128 on every target.

## Fix

Anchor the command at the real workspace so repository discovery resolves against the actual checkout:

```yaml
lint:
  definitions:
    - name: git-diff-check
      commands:
        - name: lint
          run: git -C "${workspace}" diff --check ${target}
```

This is the override documented for relative-gitdir checkouts; the upstream plugin definition is otherwise unchanged.

## Scope

The same failure affected 9 repositories in the workspace. Sibling PRs carry the identical change. `z-shell/zsh-lint` was checked and deliberately **not** patched — its gitdir is absolute, so it was never affected.

## Test plan

- [x] `trunk check --no-fix --ci --filter=git-diff-check <file>` returns `✔ No issues` (previously exit 128)
- [x] `trunk check --no-fix --ci <file>` reports no `not a git repository` errors and no missing binaries
- [x] `trunk.yaml` parses with exactly one `lint.definitions` key and one `git-diff-check` entry (guards against a duplicate-key merge that would silently drop other custom linter definitions)

## Note for reviewers

CI runners clone normally, so `.git` is a real directory there and this check was already passing in CI. The bug only reproduces in a submodule/worktree checkout — which is how the meta-workspace consumes this repo. The override is a no-op for the CI case.
