### PR TITLE
feat(audit): report default branch drift as a required setting

### DIFF
--- a/scripts/repo-settings-audit.rb
+++ b/scripts/repo-settings-audit.rb
@@ -118,6 +118,7 @@ module RepoSettingsAudit
   # lib/repository-classes.yml and override only the explicitly listed setting.
   class Baseline
     SETTINGS = %w[
+      default_branch_main
       pr_required
       deletion_blocked
       force_push_blocked
@@ -128,16 +129,16 @@ module RepoSettingsAudit
     ].freeze
 
     TABLE = {
-      1 => { "pr_required" => "R", "deletion_blocked" => "R", "force_push_blocked" => "R",
+      1 => { "default_branch_main" => "R", "pr_required" => "R", "deletion_blocked" => "R", "force_push_blocked" => "R",
              "required_status_checks" => "R", "linear_history" => "S", "signed_commits" => "S",
              "copilot_code_review" => "R" },
-      2 => { "pr_required" => "R", "deletion_blocked" => "R", "force_push_blocked" => "R",
+      2 => { "default_branch_main" => "R", "pr_required" => "R", "deletion_blocked" => "R", "force_push_blocked" => "R",
              "required_status_checks" => "R", "linear_history" => "S", "signed_commits" => "S",
              "copilot_code_review" => "R" },
-      3 => { "pr_required" => "R", "deletion_blocked" => "R", "force_push_blocked" => "R",
+      3 => { "default_branch_main" => "R", "pr_required" => "R", "deletion_blocked" => "R", "force_push_blocked" => "R",
              "required_status_checks" => "R", "linear_history" => "S", "signed_commits" => "S",
              "copilot_code_review" => "S" },
-      4 => { "pr_required" => "R", "deletion_blocked" => "R", "force_push_blocked" => "R",
+      4 => { "default_branch_main" => "R", "pr_required" => "R", "deletion_blocked" => "R", "force_push_blocked" => "R",
              "required_status_checks" => "S", "linear_history" => "S", "signed_commits" => "S",
              "copilot_code_review" => "R" }
     }.freeze
@@ -217,6 +218,7 @@ module RepoSettingsAudit
       from_classic = live_from_classic(classic_protection)
 
       live = Baseline::SETTINGS.to_h { |setting| [setting, from_rulesets.fetch(setting, false) || from_classic.fetch(setting, false)] }
+      live["default_branch_main"] = default_branch == "main"
 
       {
         "live" => live,

--- a/scripts/test-repo-settings-audit.rb
+++ b/scripts/test-repo-settings-audit.rb
@@ -165,7 +165,14 @@ class RepoSettingsAuditTest
     )
 
     assert_equal(RepoSettingsAudit::Baseline::SETTINGS.length, result.fetch("settings").length)
-    assert_equal({ "pass" => 3, "warn" => 3, "fail" => 1, "na" => 0 }, result.fetch("summary"))
+    assert_equal({ "pass" => 3, "warn" => 3, "fail" => 2, "na" => 0 }, result.fetch("summary"))
+  end
+
+  def test_evaluator_reports_default_branch_drift_as_required
+    row = RepoSettingsAudit::Evaluator.evaluate_setting(
+      klass: 4, setting: "default_branch_main", live: false, has_ci: true
+    )
+    assert_equal("fail", row.fetch("status"))
   end
 
   # --- SettingsExtractor ---------------------------------------------------


### PR DESCRIPTION
## Summary

The repository settings audit covered branch-protection rules but never checked the default branch *name*, so a repository whose default branch was not `main` passed cleanly while diverging from org policy.

## Change

- Adds `default_branch_main` as the first entry in `Baseline::SETTINGS`, marked required (`R`) across all four repository classes.
- Evaluates it from the live default branch (`default_branch == "main"`) rather than from ruleset or classic-protection state, since it is a repository attribute, not a protection rule.

## Test plan

- [x] New `test_evaluator_reports_default_branch_drift_as_required` — asserts a class-4 repository with a non-`main` default branch is reported `fail`
- [x] Updated the mixed-state fixture's expected summary (`fail` 1 → 2) to account for the new setting
- [x] `ruby scripts/test-repo-settings-audit.rb` — 38/38 pass, 0 failures

## Note

Independent of #561 (instruction-routing dedup); this branch is cut from `main` and shares no commits with it.
