### PR TITLE
fix(audit): fail closed on malformed labeler configuration

### DIFF
--- a/scripts/labeler-config-audit.rb
+++ b/scripts/labeler-config-audit.rb
@@ -96,9 +96,12 @@ module LabelerConfigAudit
   # label names in either, so read those and ignore the values entirely.
   def self.label_keys(source)
     parsed = YAML.safe_load(source, aliases: true)
-    return [] unless parsed.is_a?(Hash)
+    raise GitHubError, "labeler config must be a mapping" unless parsed.is_a?(Hash)
 
-    parsed.keys.map(&:to_s).reject(&:empty?)
+    keys = parsed.keys
+    raise GitHubError, "labeler config labels must be non-empty strings" unless keys.all? { |key| key.is_a?(String) && !key.empty? }
+
+    keys
   rescue Psych::Exception => error
     raise GitHubError, "labeler config is not valid YAML: #{error.message}"
   end

--- a/scripts/test-labeler-config-audit.rb
+++ b/scripts/test-labeler-config-audit.rb
@@ -120,6 +120,22 @@ class LabelerConfigAuditTest
     assert(error.message.include?("not valid YAML"), "unexpected message: #{error.message}")
   end
 
+  def test_non_mapping_config_is_malformed
+    files = { "z-shell/list:.github/labeler.yml" => "- type:bug\n" }
+    audit("z-shell/list", files)
+    raise "expected GitHubError"
+  rescue LabelerConfigAudit::GitHubError => error
+    assert(error.message.include?("must be a mapping"), "unexpected message: #{error.message}")
+  end
+
+  def test_empty_label_key_is_malformed
+    files = { "z-shell/empty:.github/labeler.yml" => "\"\":\n  - '*.rb'\n" }
+    audit("z-shell/empty", files)
+    raise "expected GitHubError"
+  rescue LabelerConfigAudit::GitHubError => error
+    assert(error.message.include?("non-empty strings"), "unexpected message: #{error.message}")
+  end
+
   def test_json_output_and_exit_code_on_drift
     io = StringIO.new
     code = LabelerConfigAudit.run(


### PR DESCRIPTION
## Summary

`label_keys` returned an empty array for any non-mapping document and coerced keys with `to_s`, so a malformed labeler config was silently audited as having **no labels** rather than being reported as broken. Drift in such a repository was indistinguishable from a clean result.

## Change

Raise `GitHubError` when:

- the parsed document is not a mapping (e.g. a YAML sequence), and
- any key is not a non-empty string.

Malformed configuration now surfaces as an error instead of a false pass. This matches the existing behavior for unparseable YAML, which already raised.

## Test plan

- [x] `test_non_mapping_config_is_malformed` — a sequence document raises with "must be a mapping"
- [x] `test_empty_label_key_is_malformed` — an empty-string key raises with "non-empty strings"
- [x] `ruby scripts/test-labeler-config-audit.rb` — 13/13 pass

## Note

Independent of #561 and #562; cut from `main` and shares no commits with either.
