### PR TITLE
feat(project): exclude Renovate dashboards

### DIFF
--- a/.github/workflows/project-reconcile.yml
+++ b/.github/workflows/project-reconcile.yml
@@ -9,7 +9,7 @@ on:
         default: false
         type: boolean
   schedule:
-    - cron: '17 3 * * *'
+    - cron: "17 3 * * *"
 
 concurrency:
   group: project-reconcile
@@ -32,7 +32,7 @@ jobs:
           GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
           APPLY: ${{ github.event_name == 'schedule' || inputs.apply || false }}
           ORGANIZATION: z-shell
-          PROJECT_NUMBER: '28'
+          PROJECT_NUMBER: "28"
         run: |
           set -euo pipefail
 
@@ -51,7 +51,7 @@ jobs:
           gh api --paginate \
             -H 'Accept: application/vnd.github+json' \
             "/search/issues?q=org%3A${ORGANIZATION}%20is%3Aissue%20is%3Aopen&per_page=100" \
-            --jq '.items[] | {url: .html_url, node_id: .node_id, title: .title, repository: .repository_url, author: .user.login, updated_at: .updated_at, labels: [.labels[].name]}' \
+            --jq '.items[] | {url: .html_url, node_id: .node_id, title: .title, repository: .repository_url, author: .user.login, author_type: .user.type, updated_at: .updated_at, labels: [.labels[].name]}' \
             > open-issues.ndjson
 
           : > project-items.ndjson
@@ -101,6 +101,16 @@ jobs:
                 }
               }' -f project="${project_id}" -f content="${node_id}" >/dev/null
           done < <(jq -c '.missing_open_issues[]' project-reconcile-report.json)
+
+          while IFS= read -r item; do
+            item_id="$(jq -r '.item_id' <<<"${item}")"
+            gh api graphql -f query='
+              mutation($project: ID!, $item: ID!) {
+                deleteProjectV2Item(input: {projectId: $project, itemId: $item}) {
+                  deletedItemId
+                }
+              }' -f project="${project_id}" -f item="${item_id}" >/dev/null
+          done < <(jq -c '.excluded_project_items[]' project-reconcile-report.json)
 
           echo 'Project membership reconciliation applied.'
 

--- a/renovate-config.json
+++ b/renovate-config.json
@@ -1,7 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": "Z-Shell organization preset for routine dependency version updates",
-  "extends": ["config:best-practices", ":semanticCommits"],
+  "extends": [
+    "config:best-practices",
+    ":semanticCommits",
+    ":disableVulnerabilityAlerts"
+  ],
   "timezone": "UTC",
   "schedule": ["* 0-4 * * 1"],
   "minimumReleaseAge": "3 days",

--- a/runbooks/dependency-management.md
+++ b/runbooks/dependency-management.md
@@ -16,6 +16,10 @@ Do not configure both services to create routine version updates in the same
 repository. The split avoids duplicate pull requests, lock-file conflicts, and
 unnecessary CI runs.
 
+The shared Renovate preset explicitly disables Renovate vulnerability-alert
+pull requests. Keep that setting in the central preset so Dependabot remains
+the sole security-remediation owner for every inheriting repository.
+
 The governing live decision is
 `decisions/0012-hybrid-dependency-management.md`. ADR 0012 supersedes ADR 0004;
 ADR 0004 remains only as historical rationale.

--- a/runbooks/project-tracker.md
+++ b/runbooks/project-tracker.md
@@ -16,12 +16,14 @@ organization-infrastructure work; it is not the source of truth.
 
 ## Inclusion policy
 
-The organization-wide reconciler tracks all open organization issues so that
-work cannot disappear between repositories. Project views separate workstreams:
+The organization-wide reconciler tracks actionable open organization issues so
+that work cannot disappear between repositories. It excludes Renovate
+Dependency Dashboard issues, which remain available in their owning
+repositories as automation control surfaces. Project views separate workstreams:
 
 - `Human delivery`: ordinary bugs, features, maintenance, and documentation
-- `Automation`: bot dashboards and recurring automation records
-- `Dependency maintenance`: routine dependency updates and dashboards
+- `Automation`: recurring automation records requiring maintainer action
+- `Dependency maintenance`: actionable routine dependency work
 - `Security`: security work requiring maintainer attention
 - `Administrative`: organization and repository governance
 
@@ -52,10 +54,12 @@ only one auto-add workflow. Keep it narrow while the central reconciler is
 introduced.
 
 The scheduled reconciler uses a project-scoped credential supplied as
-`PROJECT_TOKEN` to add every missing open organization issue to Project 28. It
-is additive and idempotent, emits a drift report, and never overwrites
-human-set field values. Manual dispatch remains read-only unless a maintainer
-sets `apply=true` after reviewing the report.
+`PROJECT_TOKEN` to add every missing actionable open organization issue to
+Project 28. It also removes only exact Renovate Dependency Dashboard matches,
+identified by bot type, bot login, and title. It is otherwise additive and
+idempotent, emits a drift report, and never overwrites human-set field values.
+Manual dispatch remains read-only unless a maintainer sets `apply=true` after
+reviewing the report.
 
 The target implementation is an organization-owned GitHub App with Project
 read/write permission, installed on all repositories, receiving only the
@@ -90,7 +94,7 @@ changing reconciliation behavior. The report must identify:
 - open organization issues missing from Project 28
 - project items whose source issue or pull request is no longer visible
 - unclassified workstream records
-- bot and dependency-dashboard records
+- excluded Renovate Dependency Dashboard records and any matching Project items
 - project items with conflicting or missing relationship data
 - open issues that have been stale for five days, excluding `status:blocked`
 

--- a/scripts/project_reconcile.py
+++ b/scripts/project_reconcile.py
@@ -41,6 +41,15 @@ def issue_sort_key(issue: dict[str, Any]) -> str:
     return url
 
 
+def is_renovate_dependency_dashboard(issue: dict[str, Any]) -> bool:
+    """Return whether an issue is Renovate's repository dashboard."""
+    return (
+        issue.get("author_type") == "Bot"
+        and issue.get("author") == "renovate[bot]"
+        and issue.get("title") == "Dependency Dashboard"
+    )
+
+
 def build_report(
     open_issues_path: Path,
     project_items_path: Path,
@@ -53,13 +62,16 @@ def build_report(
 
     open_issues = read_ndjson(open_issues_path)
     project_items = read_ndjson(project_items_path)
-    project_node_ids = {
-        item["node_id"]
-        for item in project_items
-        if isinstance(item.get("node_id"), str)
-    }
+    project_items_by_node_id: dict[str, list[dict[str, Any]]] = {}
+    for item in project_items:
+        node_id = item.get("node_id")
+        if isinstance(node_id, str):
+            project_items_by_node_id.setdefault(node_id, []).append(item)
+    project_node_ids = set(project_items_by_node_id)
     cutoff = parse_timestamp(now, field="now") - timedelta(days=stale_after_days)
 
+    excluded_open_issues: list[dict[str, Any]] = []
+    excluded_project_items: list[dict[str, Any]] = []
     missing_open_issues: list[dict[str, Any]] = []
     stale_open_issues: list[dict[str, Any]] = []
     for issue in open_issues:
@@ -68,20 +80,31 @@ def build_report(
             raise ValueError("issue node_id must be a string")
         updated_at = parse_timestamp(issue.get("updated_at"), field="issue updated_at")
         labels = issue.get("labels")
-        if not isinstance(labels, list) or not all(isinstance(label, str) for label in labels):
+        if not isinstance(labels, list) or not all(
+            isinstance(label, str) for label in labels
+        ):
             raise ValueError("issue labels must be a list of strings")
         issue_sort_key(issue)
+        if is_renovate_dependency_dashboard(issue):
+            excluded_open_issues.append(issue)
+            excluded_project_items.extend(project_items_by_node_id.get(node_id, []))
+            continue
         if node_id not in project_node_ids:
             missing_open_issues.append(issue)
         if updated_at < cutoff and "status:blocked" not in labels:
             stale_open_issues.append(issue)
 
+    excluded_open_issues.sort(key=issue_sort_key)
+    excluded_project_items.sort(key=issue_sort_key)
     missing_open_issues.sort(key=issue_sort_key)
     stale_open_issues.sort(key=issue_sort_key)
     return {
-        "schema": "z-shell/project-reconcile-report/v2",
+        "schema": "z-shell/project-reconcile-report/v3",
         "open_issue_count": len(open_issues),
+        "tracked_open_issue_count": len(open_issues) - len(excluded_open_issues),
         "project_content_count": len(project_items),
+        "excluded_open_issues": excluded_open_issues,
+        "excluded_project_items": excluded_project_items,
         "missing_open_issues": missing_open_issues,
         "stale_open_issues": stale_open_issues,
     }
@@ -107,7 +130,10 @@ def main() -> None:
         json.dumps(
             {
                 "open_issue_count": report["open_issue_count"],
+                "tracked_open_issue_count": report["tracked_open_issue_count"],
                 "project_content_count": report["project_content_count"],
+                "excluded_open_issue_count": len(report["excluded_open_issues"]),
+                "excluded_project_item_count": len(report["excluded_project_items"]),
                 "missing_open_issue_count": len(report["missing_open_issues"]),
                 "stale_open_issue_count": len(report["stale_open_issues"]),
             },

--- a/scripts/test_project_reconcile.py
+++ b/scripts/test_project_reconcile.py
@@ -12,7 +12,9 @@ import project_reconcile
 
 
 class ProjectReconcileTest(unittest.TestCase):
-    def write_ndjson(self, directory: Path, name: str, records: list[dict[str, object]]) -> Path:
+    def write_ndjson(
+        self, directory: Path, name: str, records: list[dict[str, object]]
+    ) -> Path:
         path = directory / name
         path.write_text("".join(json.dumps(record) + "\n" for record in records))
         return path
@@ -58,7 +60,10 @@ class ProjectReconcileTest(unittest.TestCase):
             )
 
         self.assertEqual(3, report["open_issue_count"])
+        self.assertEqual(3, report["tracked_open_issue_count"])
         self.assertEqual(1, report["project_content_count"])
+        self.assertEqual([], report["excluded_open_issues"])
+        self.assertEqual([], report["excluded_project_items"])
         self.assertEqual(
             [
                 "https://github.com/z-shell/example/issues/1",
@@ -77,7 +82,13 @@ class ProjectReconcileTest(unittest.TestCase):
             open_issues = self.write_ndjson(
                 directory,
                 "open-issues.ndjson",
-                [{"url": "https://github.com/z-shell/example/issues/1", "node_id": "issue-1", "labels": []}],
+                [
+                    {
+                        "url": "https://github.com/z-shell/example/issues/1",
+                        "node_id": "issue-1",
+                        "labels": [],
+                    }
+                ],
             )
             project_items = self.write_ndjson(directory, "project-items.ndjson", [])
 
@@ -88,6 +99,86 @@ class ProjectReconcileTest(unittest.TestCase):
                     now="2026-08-21T00:00:00Z",
                     stale_after_days=5,
                 )
+
+    def test_report_excludes_only_exact_renovate_dependency_dashboards(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            directory = Path(temporary_directory)
+            open_issues = self.write_ndjson(
+                directory,
+                "open-issues.ndjson",
+                [
+                    {
+                        "url": "https://github.com/z-shell/example/issues/1",
+                        "node_id": "dashboard",
+                        "title": "Dependency Dashboard",
+                        "author": "renovate[bot]",
+                        "author_type": "Bot",
+                        "updated_at": "2026-08-01T00:00:00Z",
+                        "labels": [],
+                    },
+                    {
+                        "url": "https://github.com/z-shell/example/issues/2",
+                        "node_id": "human-dashboard",
+                        "title": "Dependency Dashboard",
+                        "author": "maintainer",
+                        "author_type": "User",
+                        "updated_at": "2026-08-01T00:00:00Z",
+                        "labels": [],
+                    },
+                    {
+                        "url": "https://github.com/z-shell/example/issues/3",
+                        "node_id": "renovate-warning",
+                        "title": "Renovate configuration warning",
+                        "author": "renovate[bot]",
+                        "author_type": "Bot",
+                        "updated_at": "2026-08-01T00:00:00Z",
+                        "labels": [],
+                    },
+                ],
+            )
+            project_items = self.write_ndjson(
+                directory,
+                "project-items.ndjson",
+                [
+                    {
+                        "item_id": "project-dashboard",
+                        "node_id": "dashboard",
+                        "url": "https://github.com/z-shell/example/issues/1",
+                    }
+                ],
+            )
+
+            report = project_reconcile.build_report(
+                open_issues,
+                project_items,
+                now="2026-08-21T00:00:00Z",
+                stale_after_days=5,
+            )
+
+        self.assertEqual(3, report["open_issue_count"])
+        self.assertEqual(2, report["tracked_open_issue_count"])
+        self.assertEqual(
+            ["https://github.com/z-shell/example/issues/1"],
+            [issue["url"] for issue in report["excluded_open_issues"]],
+        )
+        self.assertEqual(
+            ["project-dashboard"],
+            [item["item_id"] for item in report["excluded_project_items"]],
+        )
+        self.assertEqual(
+            [
+                "https://github.com/z-shell/example/issues/2",
+                "https://github.com/z-shell/example/issues/3",
+            ],
+            [issue["url"] for issue in report["missing_open_issues"]],
+        )
+        self.assertEqual(
+            [
+                "https://github.com/z-shell/example/issues/2",
+                "https://github.com/z-shell/example/issues/3",
+            ],
+            [issue["url"] for issue in report["stale_open_issues"]],
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- exclude exact Renovate Dependency Dashboard issues from Project 28 reconciliation
- report and remove matching Project items during apply runs
- keep Renovate dashboards enabled in their owning repositories
- explicitly disable Renovate vulnerability-alert pull requests so Dependabot remains the security owner
- document the Project and dependency-management boundaries

## Safety

Dashboard classification requires all of the following:

- GitHub author type `Bot`
- author login `renovate[bot]`
- exact title `Dependency Dashboard`

A live read-only reconciliation identified exactly three excluded issues and three matching Project items. No Project mutation was applied during validation.

## Verification

- `python3 scripts/test_project_reconcile.py`
- `actionlint .github/workflows/project-reconcile.yml`
- `python3 scripts/validate-agent-policy.py`
- `npx --yes --package renovate renovate-config-validator renovate-config.json`
- `trunk check scripts/project_reconcile.py scripts/test_project_reconcile.py .github/workflows/project-reconcile.yml renovate-config.json runbooks/project-tracker.md runbooks/dependency-management.md`
- `git diff --check origin/main...HEAD`

Related: #452
