### PR TITLE
fix(deps): deduplicate GitHub Actions updates

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -4,10 +4,11 @@
   "extends": [
     "config:best-practices",
     ":semanticCommits",
+    ":approveMajorUpdates",
+    "schedule:weekly",
     ":disableVulnerabilityAlerts"
   ],
   "timezone": "UTC",
-  "schedule": ["* 0-4 * * 1"],
   "minimumReleaseAge": "3 days",
   "dependencyDashboard": true,
   "dependencyDashboardTitle": "Dependency Dashboard",
@@ -17,10 +18,9 @@
   "automerge": false,
   "packageRules": [
     {
-      "description": "Group non-major updates by package manager",
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "groupName": "{{manager}} non-major updates",
-      "groupSlug": "{{manager}}-non-major"
+      "description": "Propose only the highest available GitHub Actions release",
+      "matchManagers": ["github-actions"],
+      "separateMajorMinor": false
     },
     {
       "description": "Group non-major GitHub Actions updates",

--- a/runbooks/dependency-management.md
+++ b/runbooks/dependency-management.md
@@ -54,6 +54,18 @@ also reference it explicitly:
 }
 ```
 
+The organization preset builds on Renovate's `config:best-practices` and weekly
+schedule presets. It leaves Renovate's curated monorepo and related-package
+groups in place instead of grouping every dependency handled by the same
+manager. Broad manager-wide groups make one unrelated failure block all other
+updates and make the cause harder to isolate.
+
+GitHub Actions are the narrow exception. Their non-major updates are grouped to
+reduce workflow-only pull request volume, while major updates remain isolated
+and require Dependency Dashboard approval. Renovate is configured not to open
+parallel major and non-major branches for the same action: when both are
+available, it proposes only the highest release.
+
 Repository consumer configuration belongs at `.github/renovate.json`.
 Renovate also recognizes `renovate.json` at the repository root, but searches
 that location first and stops after the first match. Never keep both paths; a


### PR DESCRIPTION
## Summary

- make Renovate propose only the highest available GitHub Actions release instead of parallel major and non-major updates
- retain grouped non-major action updates while keeping majors isolated and Dependency Dashboard approval-gated
- replace the custom weekly cron with Renovate's maintained weekly preset
- remove broad manager-wide grouping in favor of Renovate's curated monorepo and related-package groups
- document the organization grouping and bucketing policy

## Why

F-Sy-H's Dependency Dashboard listed both `actions/checkout` v6.1.0 and v7.0.1 from the same v6.0.3 baseline. Renovate's default major/non-major buckets created two proposals for one dependency. Setting `separateMajorMinor` to `false` for the GitHub Actions manager makes Renovate select the highest applicable release while leaving unrelated major action upgrades isolated.

Broad manager-wide grouping also coupled unrelated dependencies. The revised preset keeps Renovate's maintained smart groups and limits the organization-wide custom group to non-major GitHub Actions updates.

## Verification

- Renovate local-platform reproduction against `actions/checkout` v6.0.3:
  - old preset: 2 flattened updates, v6.1.0 and v7.0.1
  - new preset: 1 flattened update, v7.0.1
- `renovate-config-validator --strict --no-global renovate-config.json .github/renovate.json`: passed with Renovate's documented RegExp fallback because native RE2 was unavailable
- Trunk: 2 changed files checked, no issues
- agent policy and Zsh standard policy validators: passed
- policy validator unit tests: 183 passed
- `git diff --check`: passed

Relates to #452.
Addresses z-shell/F-Sy-H#111.
