### PR TITLE
docs(branching): fix the promotion ancestry precondition

### DIFF
--- a/runbooks/branch-protection.md
+++ b/runbooks/branch-protection.md
@@ -71,14 +71,30 @@ branch name. Run the guard on a real pull request before adding its context to
 Promotion preserves Git ancestry. Never squash or rebase a persistent branch
 into its stable branch.
 
-1. Fetch both remote branches and verify that `main` is an ancestor of `next`.
-   This proves that no hotfix or other stable-only commit was omitted:
+1. Fetch both remote branches and verify that the stable branch carries no
+   content the candidate lacks. This proves that no hotfix or other
+   stable-only commit was omitted:
 
    ```sh
    git fetch origin main next
-   git merge-base --is-ancestor origin/main origin/next
+   test -z "$(git diff --name-only origin/next...origin/main)"
    git log --left-right --graph --oneline origin/main...origin/next
    ```
+
+   Do **not** test `git merge-base --is-ancestor origin/main origin/next`. That
+   check cannot pass after a successful promotion and does not mean the branches
+   have diverged in content. Promotion creates a merge commit on `main`, and
+   that commit never exists on `next`, so `main` stops being an ancestor of
+   `next` the moment a promotion lands. Treating the failure as drift produces a
+   no-content reconciliation merge before every promotion, which is exactly the
+   routine back-merge ADR-0019 removed.
+
+   The empty three-dot diff is the real precondition: it is satisfied both
+   immediately after a promotion and after ordinary work continues on `next`,
+   and it still fails when a genuine stable-only commit, such as an unmerged
+   hotfix, exists on `main`. When it fails, inspect
+   `git log --oneline origin/next..origin/main` to identify the omitted commit
+   and merge it forward through the hotfix synchronization procedure below.
 
 2. Open or update a pull request with base `main`, head `next`, and a
    Conventional Commit title such as `chore: promote next to main`.
@@ -120,6 +136,13 @@ continues, synchronize it into `next`:
 2. merge current `main` into that branch with a signed merge commit;
 3. open a pull request into `next` and preserve the merge commit; and
 4. verify `git merge-base --is-ancestor origin/main origin/next` after merge.
+
+This is the one direction in which the ancestor test is correct, because
+synchronization merges `main` into `next` and preserves the merge commit. It is
+the mirror image of the promotion precondition, where the same test is wrong.
+Keep the two straight: synchronization makes `main` an ancestor of `next`, and
+promotion makes `next` an ancestor of `main`. Neither relationship survives in
+both directions at once.
 
 Do not reset, rebase, or force-push the persistent branch to synchronize a
 hotfix. If the trees conflict, resolve them in the reviewed synchronization


### PR DESCRIPTION
## Summary

Fixes the promotion precondition in `runbooks/branch-protection.md`, which
required a check that cannot pass after any successful promotion.

Closes #573

## Problem

Step 1 of the promotion procedure required:

```sh
git merge-base --is-ancestor origin/main origin/next
```

Promotion creates a merge commit on `main` that never exists on `next`, so
`main` stops being an ancestor of `next` the moment a promotion lands. ADR-0019
states the opposite property, that promotion needs no back-merge because the
promoted `next` commit becomes an ancestor of `main`. Both cannot hold.

Reading the guaranteed failure as drift has produced three no-content
reconciliation merges in `z-shell/zi` (`9a4fa51`, `b0ebcc3`, `73df7bf`), each
contributing zero files to `next`. That is the routine back-merge ADR-0019 set
out to remove.

## Change

Replaces the precondition with an empty three-dot content diff, which asserts
what the step was actually trying to establish: the stable branch carries no
content the candidate lacks.

```sh
git fetch origin main next
test -z "$(git diff --name-only origin/next...origin/main)"
```

Also documents why the ancestor test is correct in the hotfix-synchronization
step, where the merge runs in the opposite direction. That asymmetry is the
likely origin of the defect.

## Verification

Both checks exercised across the four states a persistent integration branch can
occupy, in a scratch repository:

| Scenario | old check | new check | Correct |
| -------- | --------- | --------- | ------- |
| Just promoted, healthy | fail | pass | pass |
| Work continued on `next`, healthy | fail | pass | pass |
| Unmerged hotfix on `main` | fail | **fail** | fail |
| Hotfix synchronized forward | pass | pass | pass |

The third row confirms this is not a check that passes unconditionally: a
genuine stable-only commit is still caught.

Applied to the live pending `z-shell/zi` candidate, the new check passes where
the old one falsely failed, and `git diff --name-only origin/next...origin/main`
is empty.

`trunk check` reports no issues on the changed file.

## Follow-up

`z-shell/zi` carries the same defect in
`.github/PULL_REQUEST_TEMPLATE/promotion.md`, which would reimpose the
impossible check on the promotion pull request itself. Tracked separately and
should land before the pending promotion.
