### PR TITLE
fix(decisions): stop crediting AI agents as decision-record deciders

### DIFF
--- a/decisions/0004-dependabot-unification.md
+++ b/decisions/0004-dependabot-unification.md
@@ -2,7 +2,7 @@
 
 - **Status:** ACCEPTED
 - **Date:** 2026-05-20
-- **Deciders:** ss-o, Gemini CLI
+- **Deciders:** ss-o
 - **Supersedes:** None
 - **Superseded by:** `decisions/0012-hybrid-dependency-management.md`
 

--- a/decisions/0005-workflow-naming-conventions.md
+++ b/decisions/0005-workflow-naming-conventions.md
@@ -2,7 +2,7 @@
 
 - **Status:** ACCEPTED
 - **Date:** 2026-05-21
-- **Deciders:** ss-o, Claude Code
+- **Deciders:** ss-o
 - **Supersedes:** None
 - **Superseded by:** None
 

--- a/decisions/0006-wiki-content-root-boundaries.md
+++ b/decisions/0006-wiki-content-root-boundaries.md
@@ -2,7 +2,7 @@
 
 - **Status:** ACCEPTED
 - **Date:** 2026-05-29
-- **Deciders:** ss-o, Claude Code
+- **Deciders:** ss-o
 - **Supersedes:** None
 - **Superseded by:** None
 
@@ -20,7 +20,7 @@ The three content roots have fixed, non-overlapping scopes:
 2. `community/` holds **Z-Shell ecosystem community content only** — contributing, the Zsh handbook/plugin standard, ZUnit.
 3. `ecosystem/` holds the third-party catalog: annexes, packages, plugins.
 
-Maintainer, operational, and infrastructure runbooks do not belong on the public wiki at all. They live in `z-shell/.github/runbooks/`, which is the established home for operational documentation. Feature *implementation* (Edge Functions, migrations, scripts) still lives in the owning repository.
+Maintainer, operational, and infrastructure runbooks do not belong on the public wiki at all. They live in `z-shell/.github/runbooks/`, which is the established home for operational documentation. Feature _implementation_ (Edge Functions, migrations, scripts) still lives in the owning repository.
 
 These boundaries are recorded in the wiki `AGENTS.md` (with `CLAUDE.md` as a symlink to it) and the wiki authoring instructions (`docs-authoring.instructions.md`, `agent-docusaurus-writer.instructions.md`).
 

--- a/decisions/0007-release-publication-flow.md
+++ b/decisions/0007-release-publication-flow.md
@@ -2,7 +2,7 @@
 
 - **Status:** ACCEPTED
 - **Date:** 2026-05-26
-- **Deciders:** ss-o, Claude Code
+- **Deciders:** ss-o
 - **Supersedes:** None
 - **Superseded by:** None
 

--- a/decisions/README.md
+++ b/decisions/README.md
@@ -9,26 +9,26 @@ Check: python3 scripts/decision-records.py --check
 Durable organization decisions. Draft new records with `runbooks/adr.md`; only
 a maintainer moves a record from `PROPOSED` to `ACCEPTED`.
 
-| ADR                                                     | Title                                                          | Status   | Date       | Deciders          |
-| ------------------------------------------------------- | -------------------------------------------------------------- | -------- | ---------- | ----------------- |
-| [0001](0001-meta-repo-and-agents-md.md)                 | Adopt a meta-repo pattern centered on `AGENTS.md`              | ACCEPTED | 2026-05-29 | ss-o              |
-| [0002](0002-zi-as-canonical-plugin-manager.md)          | `zi` is the canonical plugin manager for the z-shell ecosystem | ACCEPTED | 2026-05-29 | ss-o              |
-| [0003](0003-conventional-commits.md)                    | Adopt Conventional Commits across z-shell repositories         | ACCEPTED | 2026-05-29 | ss-o              |
-| [0004](0004-dependabot-unification.md)                  | Standardize on Dependabot for Dependency Management            | ACCEPTED | 2026-05-20 | ss-o, Gemini CLI  |
-| [0005](0005-workflow-naming-conventions.md)             | No Emojis in Workflow and Job Name Fields                      | ACCEPTED | 2026-05-21 | ss-o, Claude Code |
-| [0006](0006-wiki-content-root-boundaries.md)            | Wiki Content-Root Boundaries                                   | ACCEPTED | 2026-05-29 | ss-o, Claude Code |
-| [0007](0007-release-publication-flow.md)                | Release and Publication Flow                                   | ACCEPTED | 2026-05-26 | ss-o, Claude Code |
-| [0008](0008-branching-model.md)                         | Branching Model                                                | ACCEPTED | 2026-07-25 | ss-o              |
-| [0009](0009-testing-ci-strategy.md)                     | Testing and CI Strategy                                        | ACCEPTED | 2026-07-25 | ss-o              |
-| [0010](0010-security-incident-response.md)              | Security Incident Response                                     | PROPOSED | 2026-05-29 | TBD               |
-| [0011](0011-zsh-lint-semantic-analyzer-architecture.md) | zsh-lint Conditional Semantic Analysis Pipeline                | ACCEPTED | 2026-07-25 | ss-o              |
-| [0012](0012-hybrid-dependency-management.md)            | Split Dependency Updates Between Renovate and Dependabot       | ACCEPTED | 2026-06-21 | ss-o              |
-| [0013](0013-repository-settings-baseline.md)            | Repository Settings Baseline by Class                          | ACCEPTED | 2026-07-25 | ss-o              |
-| [0014](0014-portable-agent-instruction-architecture.md) | Adopt portable agent-instruction delivery                      | ACCEPTED | 2026-07-23 | ss-o              |
-| [0015](0015-zsh-scripting-standard.md)                  | Adopt an organization-wide Zsh scripting standard              | ACCEPTED | 2026-08-27 | ss-o              |
-| [0016](0016-promotion-trigger-criteria.md)              | Next-to-Main Promotion Trigger Criteria                        | ACCEPTED | 2026-08-16 | ss-o              |
-| [0017](0017-licensing-standard-by-provenance.md)        | Licensing Standard by Provenance and Consumption               | ACCEPTED | 2026-08-18 | ss-o              |
-| [0018](0018-portable-worktree-management.md)            | Adopt Portable Worktree Management                             | ACCEPTED | 2026-08-27 | ss-o              |
-| [0019](0019-trunk-on-main-default.md)                   | Trunk-on-Main Default with a Zi Integration Exception          | ACCEPTED | 2026-08-28 | ss-o              |
-| [0020](0020-adopt-zsh-plugin-standard-2.md)             | Adopt Zsh Plugin Standard 2 as a Clean Portable Contract       | ACCEPTED | 2026-08-28 | ss-o              |
-| [0021](0021-derive-chroma-knowledge-at-runtime.md)      | Derive Chroma Command Knowledge at Runtime                     | ACCEPTED | 2026-08-29 | ss-o              |
+| ADR                                                     | Title                                                          | Status   | Date       | Deciders |
+| ------------------------------------------------------- | -------------------------------------------------------------- | -------- | ---------- | -------- |
+| [0001](0001-meta-repo-and-agents-md.md)                 | Adopt a meta-repo pattern centered on `AGENTS.md`              | ACCEPTED | 2026-05-29 | ss-o     |
+| [0002](0002-zi-as-canonical-plugin-manager.md)          | `zi` is the canonical plugin manager for the z-shell ecosystem | ACCEPTED | 2026-05-29 | ss-o     |
+| [0003](0003-conventional-commits.md)                    | Adopt Conventional Commits across z-shell repositories         | ACCEPTED | 2026-05-29 | ss-o     |
+| [0004](0004-dependabot-unification.md)                  | Standardize on Dependabot for Dependency Management            | ACCEPTED | 2026-05-20 | ss-o     |
+| [0005](0005-workflow-naming-conventions.md)             | No Emojis in Workflow and Job Name Fields                      | ACCEPTED | 2026-05-21 | ss-o     |
+| [0006](0006-wiki-content-root-boundaries.md)            | Wiki Content-Root Boundaries                                   | ACCEPTED | 2026-05-29 | ss-o     |
+| [0007](0007-release-publication-flow.md)                | Release and Publication Flow                                   | ACCEPTED | 2026-05-26 | ss-o     |
+| [0008](0008-branching-model.md)                         | Branching Model                                                | ACCEPTED | 2026-07-25 | ss-o     |
+| [0009](0009-testing-ci-strategy.md)                     | Testing and CI Strategy                                        | ACCEPTED | 2026-07-25 | ss-o     |
+| [0010](0010-security-incident-response.md)              | Security Incident Response                                     | PROPOSED | 2026-05-29 | TBD      |
+| [0011](0011-zsh-lint-semantic-analyzer-architecture.md) | zsh-lint Conditional Semantic Analysis Pipeline                | ACCEPTED | 2026-07-25 | ss-o     |
+| [0012](0012-hybrid-dependency-management.md)            | Split Dependency Updates Between Renovate and Dependabot       | ACCEPTED | 2026-06-21 | ss-o     |
+| [0013](0013-repository-settings-baseline.md)            | Repository Settings Baseline by Class                          | ACCEPTED | 2026-07-25 | ss-o     |
+| [0014](0014-portable-agent-instruction-architecture.md) | Adopt portable agent-instruction delivery                      | ACCEPTED | 2026-07-23 | ss-o     |
+| [0015](0015-zsh-scripting-standard.md)                  | Adopt an organization-wide Zsh scripting standard              | ACCEPTED | 2026-08-27 | ss-o     |
+| [0016](0016-promotion-trigger-criteria.md)              | Next-to-Main Promotion Trigger Criteria                        | ACCEPTED | 2026-08-16 | ss-o     |
+| [0017](0017-licensing-standard-by-provenance.md)        | Licensing Standard by Provenance and Consumption               | ACCEPTED | 2026-08-18 | ss-o     |
+| [0018](0018-portable-worktree-management.md)            | Adopt Portable Worktree Management                             | ACCEPTED | 2026-08-27 | ss-o     |
+| [0019](0019-trunk-on-main-default.md)                   | Trunk-on-Main Default with a Zi Integration Exception          | ACCEPTED | 2026-08-28 | ss-o     |
+| [0020](0020-adopt-zsh-plugin-standard-2.md)             | Adopt Zsh Plugin Standard 2 as a Clean Portable Contract       | ACCEPTED | 2026-08-28 | ss-o     |
+| [0021](0021-derive-chroma-knowledge-at-runtime.md)      | Derive Chroma Command Knowledge at Runtime                     | ACCEPTED | 2026-08-29 | ss-o     |

--- a/scripts/decision-records.py
+++ b/scripts/decision-records.py
@@ -48,6 +48,17 @@ ALLOWED_STATUSES = (
 UNRESOLVED_DECIDERS = ("TBD", "None", "")
 DATE_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
+# A decision record names the humans who hold decision authority. Organization
+# policy bans crediting a bot or AI agent as a co-author, and runbooks/adr.md
+# reserves acceptance for a maintainer, so an automation identity can never be
+# a decider. The commit-msg hook enforces the same rule for commit trailers;
+# this is the decision-record half of it.
+AGENT_DECIDER_PATTERN = re.compile(
+    r"\[bot\]|\b(?:claude(?:\s+code)?|copilot|gemini(?:\s+cli)?|codex|cursor"
+    r"|devin|openai|anthropic|chatgpt|gpt-\d)\b",
+    re.IGNORECASE,
+)
+
 INDEX_HEADER = """<!--
 GENERATED FILE. DO NOT EDIT DIRECTLY.
 Regenerate: python3 scripts/decision-records.py
@@ -194,6 +205,18 @@ def _validate_record(
                 "an ACCEPTED record must name the accepting maintainer",
                 "record the accepting maintainer's handle in Deciders "
                 "(see runbooks/adr.md)",
+            )
+        )
+
+    agent_match = AGENT_DECIDER_PATTERN.search(record.deciders)
+    if agent_match is not None:
+        errors.append(
+            error(
+                path,
+                f"Deciders credits the automation identity "
+                f"{agent_match.group(0)!r}",
+                "list only the humans who hold decision authority; an agent "
+                "may draft a record but never decides it (see runbooks/adr.md)",
             )
         )
 

--- a/scripts/test_decision_records.py
+++ b/scripts/test_decision_records.py
@@ -87,6 +87,28 @@ class DecisionRecordTests(unittest.TestCase):
         self.write_record("0001-proposed.md", text)
         self.assertEqual(self.errors(), [])
 
+    def test_rejects_ai_agent_decider(self) -> None:
+        for identity in (
+            "Claude Code",
+            "Gemini CLI",
+            "Copilot",
+            "Codex",
+            "renovate[bot]",
+        ):
+            with self.subTest(identity=identity):
+                self.write_record(
+                    "0001-agent-decider.md",
+                    VALID_RECORD.replace("ss-o", f"ss-o, {identity}"),
+                )
+                errors = self.errors()
+                self.assertTrue(any("automation identity" in e for e in errors), errors)
+
+    def test_allows_human_deciders(self) -> None:
+        self.write_record(
+            "0001-humans.md", VALID_RECORD.replace("ss-o", "ss-o, wicoop")
+        )
+        self.assertEqual(self.errors(), [])
+
     def test_rejects_unknown_status(self) -> None:
         self.write_record("0001-unknown.md", VALID_RECORD.replace("ACCEPTED", "MAYBE"))
         errors = self.errors()

--- a/scripts/test_validate_zsh_standard_policy.py
+++ b/scripts/test_validate_zsh_standard_policy.py
@@ -3525,12 +3525,8 @@ class ZshStandardPolicyValidatorTests(unittest.TestCase):
                 [[ $0 == "$caller_zero" ]] || exit 34
                 """)
             direct_source = str(entry_path)
-            direct_relative_source = str(
-                entry_path.relative_to(temporary_directory)
-            )
-            manager_source = str(
-                plugin_root / "manager [literal]*? plugin.plugin.zsh"
-            )
+            direct_relative_source = str(entry_path.relative_to(temporary_directory))
+            manager_source = str(plugin_root / "manager [literal]*? plugin.plugin.zsh")
             manager_raw_source = str(
                 plugin_root
                 / "discarded [literal]*? segment"


### PR DESCRIPTION
## Summary

Four accepted decision records credited an automation identity in `Deciders`:

| ADR  | Was                    | Now     |
| ---- | ---------------------- | ------- |
| 0004 | `ss-o, Gemini CLI`     | `ss-o`  |
| 0005 | `ss-o, Claude Code`    | `ss-o`  |
| 0006 | `ss-o, Claude Code`    | `ss-o`  |
| 0007 | `ss-o, Claude Code`    | `ss-o`  |

This contradicts two existing rules. Organization policy bans crediting a bot or AI agent as a co-author, enforced for commit trailers by the `commit-msg` hook in `scripts/git-hooks`. And `runbooks/adr.md` reserves decision authority for a maintainer: an agent may draft a record, it never decides one.

In each case `ss-o` was the actual decider, so the agent is dropped rather than the record rewritten. No decision content changed.

This was surfaced by the decision index added in #576 — putting all 21 records in one table made the four outliers visible immediately, which is the kind of drift the index exists to catch.

## Enforcement

Prose alone would drift back, so `scripts/decision-records.py` now rejects an automation identity in `Deciders`. This is the decision-record half of the rule the `commit-msg` hook already enforces for commit trailers, matching `[bot]` suffixes and known agent product names. It runs in CI with the rest of the record contract.

Verified the check flags exactly the four known records and nothing else before correcting them, so the pattern is not over-broad. `test_allows_human_deciders` pins that a multi-human `Deciders` value stays valid.

## Pre-existing defects also fixed

Both were latent because the CI lint job only scans files changed by a pull request, so a finding in an untouched file never surfaces until something else edits that file.

- `scripts/test_validate_zsh_standard_policy.py` failed `black` on a clean checkout of `main`. Reported in #576; fixed here.
- `decisions/0006-wiki-content-root-boundaries.md` had `prettier` emphasis-style drift (`*implementation*` to `_implementation_`), surfaced because this change touches that file.

Worth noting: a whole-repository `trunk check --all` reports roughly 70 further findings across 288 files, all in files untouched by this change. That backlog is out of scope here and would need its own cleanup pass.

## Verification

```
python3 -m unittest scripts/test_decision_records.py             17 tests, OK
python3 -m unittest scripts/test_validate_agent_policy.py        84 tests, OK
python3 -m unittest scripts/test_validate_zsh_standard_policy.py 99 tests, OK
python3 scripts/validate-zsh-standard-policy.py                  passed
python3 scripts/validate-agent-policy.py                         passed
python3 scripts/decision-records.py --check                      passed
trunk check --no-fix                                             27 files, no issues
```
