### PR TITLE
fix(ci): render metrics with an org-scoped token and curate Pages

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -28,7 +28,6 @@ jobs:
       metrics_svg: metrics/plugin/metrics.svg
       repositories_metrics_svg: metrics/plugin/repositories_metrics.svg
       followup_svg: metrics/plugin/followup/followup.svg
-      stargazers_worldmap_svg: metrics/plugin/stargazers/worldmap.svg
       zi_followup_svg: metrics/plugin/followup/zi_followup.svg
       wiki_followup_svg: metrics/plugin/followup/wiki_followup.svg
       f-sy-h_followup_svg: metrics/plugin/followup/f-sy-h_followup.svg
@@ -37,37 +36,32 @@ jobs:
       - uses: lowlighter/metrics@65836723097537a54cd8eb90f61839426b4266b6
         with:
           filename: ${{ env.metrics_svg }}
-          token: ${{ github.token }}
+          token: ${{ secrets.METRICS_TOKEN }}
+          committer_token: ${{ github.token }}
           user: ${{ github.repository_owner }}
           committer_branch: metrics
           base: header
+          plugins_errors_fatal: yes
       - uses: lowlighter/metrics@65836723097537a54cd8eb90f61839426b4266b6
         with:
           filename: ${{ env.repositories_metrics_svg }}
-          token: ${{ github.token }}
+          token: ${{ secrets.METRICS_TOKEN }}
+          committer_token: ${{ github.token }}
           user: ${{ github.repository_owner }}
           committer_branch: metrics
           base: repositories
-      - uses: lowlighter/metrics@65836723097537a54cd8eb90f61839426b4266b6
-        with:
-          filename: ${{ env.stargazers_worldmap_svg }}
-          token: ${{ github.token }}
-          base: ""
-          user: ${{ github.repository_owner }}
-          committer_branch: metrics
-          plugin_stargazers: true
-          plugin_stargazers_charts: no
-          plugin_stargazers_worldmap: yes
-          plugin_stargazers_worldmap_token: ${{ secrets.GOOGLE_MAP_TOKEN }}
+          plugins_errors_fatal: yes
       - uses: lowlighter/metrics@65836723097537a54cd8eb90f61839426b4266b6
         with:
           filename: ${{ env.followup_svg }}
-          token: ${{ github.token }}
+          token: ${{ secrets.METRICS_TOKEN }}
+          committer_token: ${{ github.token }}
           base: ""
           user: ${{ github.repository_owner }}
           committer_branch: metrics
           plugin_followup: yes
           plugin_followup_indepth: yes
+          plugins_errors_fatal: yes
       - uses: lowlighter/metrics@65836723097537a54cd8eb90f61839426b4266b6
         with:
           filename: ${{ env.zi_followup_svg }}
@@ -79,6 +73,7 @@ jobs:
           committer_branch: metrics
           repo: zi
           plugin_followup: yes
+          plugins_errors_fatal: yes
       - uses: lowlighter/metrics@65836723097537a54cd8eb90f61839426b4266b6
         with:
           filename: ${{ env.wiki_followup_svg }}
@@ -90,6 +85,7 @@ jobs:
           committer_branch: metrics
           repo: wiki
           plugin_followup: yes
+          plugins_errors_fatal: yes
       - uses: lowlighter/metrics@65836723097537a54cd8eb90f61839426b4266b6
         with:
           filename: ${{ env.f-sy-h_followup_svg }}
@@ -101,3 +97,4 @@ jobs:
           committer_branch: metrics
           repo: f-sy-h
           plugin_followup: yes
+          plugins_errors_fatal: yes

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,43 +1,118 @@
-# Simple workflow for deploying static content to GitHub Pages
+---
 name: Deploy static content to Pages
 
 on:
-  # Runs on pushes targeting the default branch
   push:
-    branches: ["main"]
+    branches: [main]
+    paths:
+      - .github/workflows/static.yml
+      - profile/**
+  workflow_run:
+    workflows:
+      - Z Metrics
+      - Z Reader
+      - Z PageSpeed Insights
+    types: [completed]
+  workflow_dispatch: {}
 
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
+permissions: {}
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
-  group: "pages"
+  group: pages
   cancel-in-progress: false
 
 jobs:
-  # Single deploy job since we're just deploying
   deploy:
+    if: >-
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+      - name: Check out main
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          # Upload entire repository
-          path: '.'
+          ref: main
+          path: main
+
+      - name: Check out generated metrics assets
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          ref: metrics
+          path: metrics-branch
+
+      - name: Stage curated asset set
+        env:
+          SITE: ${{ runner.temp }}/site
+        run: |
+          set -euo pipefail
+          rm -rf "${SITE}"
+          mkdir -p "${SITE}"
+          # Organization profile imagery published from main.
+          if [ -d main/profile/img ]; then
+            mkdir -p "${SITE}/profile"
+            cp -R main/profile/img "${SITE}/profile/img"
+          fi
+          # Generated metrics SVGs published from the metrics branch.
+          if [ -d metrics-branch/metrics ]; then
+            cp -R metrics-branch/metrics "${SITE}/metrics"
+          fi
+          # Publish nothing that is not an image or the generated index.
+          find "${SITE}" -type f \
+            ! -name '*.svg' ! -name '*.png' ! -name '*.jpg' \
+            ! -name '*.jpeg' ! -name '*.webp' ! -name '*.ico' \
+            -print -delete
+          find "${SITE}" -type d -empty -delete
+          echo "Staged asset set:"
+          find "${SITE}" -type f | sort
+
+      - name: Generate index
+        env:
+          SITE: ${{ runner.temp }}/site
+        run: |
+          set -euo pipefail
+          {
+            printf '%s\n' '<!DOCTYPE html>'
+            printf '%s\n' '<html lang="en">'
+            printf '%s\n' '<head>'
+            printf '%s\n' '<meta charset="utf-8">'
+            printf '%s\n' '<meta name="viewport" content="width=device-width, initial-scale=1">'
+            printf '%s\n' '<title>z-shell assets</title>'
+            printf '%s\n' '</head>'
+            printf '%s\n' '<body>'
+            printf '%s\n' '<h1>z-shell published assets</h1>'
+            printf '%s\n' '<p>Generated metrics and organization imagery.</p>'
+            printf '%s\n' '<ul>'
+          } >"${SITE}/index.html"
+          (
+            cd "${SITE}"
+            find . -type f \( -name '*.svg' -o -name '*.png' \) \
+              | sed 's|^\./||' | sort \
+              | while IFS= read -r asset; do
+                  printf '<li><a href="%s">%s</a></li>\n' "${asset}" "${asset}"
+                done
+          ) >>"${SITE}/index.html"
+          {
+            printf '%s\n' '</ul>'
+            printf '%s\n' '</body>'
+            printf '%s\n' '</html>'
+          } >>"${SITE}/index.html"
+
+      - name: Setup Pages
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
+        with:
+          path: ${{ runner.temp }}/site
+
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5


### PR DESCRIPTION
## Summary

The organization summary embedded at https://wiki.zshell.dev/docs#summary rendered
`NaN members` and zeroed repository totals. The cause was the token, not CI
permissions: the workflow ran green on every schedule.

`lowlighter/metrics` rejects `GITHUB_TOKEN` because it fetches data outside the
current repository, detecting it by the absence of an `x-oauth-scopes` header.
Four of the seven steps passed `${{ github.token }}`. Evidence from run
33300567276 (conclusion: success):

| step | output | token validity | API calls |
| ---- | ------ | -------------- | --------- |
| 1 | `metrics.svg` | (could not verify) | REST 0 / GraphQL 0 |
| 2 | `repositories_metrics.svg` | (could not verify) | 7 / 22 |
| 3 | `worldmap.svg` | (could not verify) | - |
| 4 | `followup.svg` | (could not verify) | - |
| 5-7 | `*_followup.svg` | seems ok | populated |

Step 1 fetched nothing and still exited `Success` because `plugins_errors_fatal`
was unset. `base/index.mjs` assigns `{totalCount: NaN}` when the org field query
fails, which is the `NaN members` string. The three steps already using
`METRICS_TOKEN` rendered real figures throughout, isolating the token as the
variable.

Rendered text of the two images the wiki embeds, before this change:

- `metrics.svg`: `Joined GitHub 4 years ago ... NaN members ... Verified`
- `repositories_metrics.svg`: `90 Repositories, 0 Releases, 0 Packages, 0 Sponsors, 0 Stargazers, 0 Forkers, 0 Watchers`

Ground truth from the API: 4 members, 88 non-fork repositories, 2124 stars,
271 forks, 95 watchers, 100 releases.

## Changes

**`metrics.yml`**

- Pass `METRICS_TOKEN` to every step; keep `GITHUB_TOKEN` as `committer_token`.
- Set `plugins_errors_fatal: yes` so a failed fetch fails the run rather than
  publishing placeholder output.
- Remove the stargazers worldmap step. `GOOGLE_MAP_TOKEN` exists in neither
  repository nor organization secrets, so it only ever rendered
  `Google Maps API token is not set`.

**`static.yml`**

Pages was serving the whole repository from `main` via `path: '.'`, publishing
`runbooks/`, `decisions/`, `lib/` and `.trunk/` while omitting the generated
SVGs entirely. Verified against the live site before this change:

```
200  /AGENTS.md
200  /decisions/README.md
200  /profile/img/logo.svg
404  /metrics/plugin/metrics.svg
404  /
```

Now stages a curated set: `profile/img/**` from `main` plus `metrics/**` from the
`metrics` branch, filtered to image extensions, with a generated index. Adds
`workflow_run` triggers on Z Metrics, Z Reader and Z PageSpeed Insights so new
renders reach Pages without waiting for an unrelated push to `main`.

Note the repository's Pages `source` field still reads `branch: metrics`, but
`build_type` is `workflow`, so that field is inert and `static.yml` is the real
publisher.

## Related

The `metrics` branch was reset separately (`029e83a1` -> `4fec54d3`). It had been
branched from `main` rather than created empty, so it carried 104 stale files
frozen at 2026-05-18, including `gh-deploy-assets.yml` and `gh-push.yml`. Those
two were unreachable: absent from `main`, unregistered in `gh workflow list`,
and targeting a `gh-pages` branch that does not exist. All retained SVG blobs
were verified byte-identical before the push. Recovery SHA: `029e83a1`.

Relates to #485.

## Verification

- `trunk check --filter=actionlint,shellcheck,prettier` clean on both workflows;
  actionlint confirmed genuinely executing via an injected fault.
- All four new action pins verified to resolve to their claimed tags.
- Wiki-embedded raw URLs confirmed `200` after the branch rewrite.
- Post-merge: dispatch Z Metrics and confirm the rendered SVG text carries real
  figures, then confirm the SVGs are reachable on Pages.
