### PR TITLE
docs(testing): isolate autoload paths from other checkouts

### DIFF
--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -58,6 +58,9 @@ Do not add an org-wide coverage number.
   integration or system tests are also valid when they exercise boundaries that
   do not fit a unit test.
 - Test plugins by sourcing them in a clean Zsh session; there is no build step.
+- Before testing autoloaded functions, clear or rebuild inherited `FPATH` and
+  `fpath` from the subject checkout. A same-named entry from another worktree
+  or installation can make tests exercise stale code.
 - Prime lifecycle observers before the baseline. Compare functions, parameters
   and attributes, aliases, options, traps, modules, hooks, widgets, bindings,
   styles, `path`, and `fpath` without printing captured values.


### PR DESCRIPTION
## Summary

- Require Zsh tests to control `FPATH` and `fpath` from the checkout under test.
- Prevent another worktree or installation from silently supplying a same-named autoload.

## Evidence

While validating z-shell/F-Sy-H#77 in z-shell/F-Sy-H#134, ZUnit initially executed `_fsh_make_targets` from a stale primary checkout inherited through `FPATH`. Clearing `FPATH` made the regression exercise the intended worktree and pass.

## Instruction impact review

1. Classification: scoped testing guidance.
2. Consumers: Codex, Claude Code, Copilot, Gemini CLI, and humans in repositories testing Zsh autoloads.
3. Canonical owner: `.github/instructions/testing.instructions.md` remains the correct owner.
4. Duplication and contradiction: none found. Existing Zsh guidance controls trusted paths but does not prevent cross-checkout test selection.
5. Routing: no manifest change. `instruction-testing` already routes this file for testing tasks.
6. Runtime delivery: all supported runtimes receive the required scoped instruction through the manifest, with no optional hook or skill dependency.
7. Generated output: no adapter or generated composite changes. `AGENTS.md` and its size limit are unaffected.

## Verification

- `python3 scripts/validate-agent-policy.py`
- `python3 -m unittest scripts/test_validate_agent_policy.py -v` (84 tests)
- `python3 scripts/validate-zsh-standard-policy.py`
- `trunk check --no-progress --no-fix .github/instructions/testing.instructions.md`
- `git diff --check`

## Agent handoff

No handoff needed.
