### PR TITLE
docs(skill): document manual issue links

### DIFF
--- a/.github/skills/github-issues/SKILL.md
+++ b/.github/skills/github-issues/SKILL.md
@@ -56,6 +56,31 @@ only for capabilities the installed high-level command does not expose.
    rendered line breaks.
 6. Report the resulting URL.
 
+## Pull-request issue links
+
+Closing keywords create a Development link only when the pull request targets
+the repository's default branch. If repository policy requires a non-default
+base, preserve that base and create a manual closing reference after explicit
+authority. Do not retarget the pull request merely to activate the keyword. A
+manual link does not change GitHub's default-branch requirement for closing the
+issue.
+
+Prefer a discovered high-level capability. If none exists, confirm the current
+GraphQL schema exposes `addCloseIssueReferences` with `issueId` and
+`pullRequestIds`, then use the issue and pull-request node IDs:
+
+```sh
+gh api graphql \
+  -f query='mutation($issueId: ID!, $pullRequestIds: [ID!]!) { addCloseIssueReferences(input: {issueId: $issueId, pullRequestIds: $pullRequestIds}) { issue { number } } }' \
+  -f issueId='ISSUE_NODE_ID' \
+  -F 'pullRequestIds[]=PR_NODE_ID'
+```
+
+Keep the complete `pullRequestIds[]=...` field quoted in Zsh so `NOMATCH` does
+not reject it before `gh` runs. Read both `closedByPullRequestsReferences` on
+the issue and `closingIssuesReferences` on the pull request back after the
+mutation.
+
 Never expose tokens, use destructive issue operations without exact authority,
 or treat tool availability as permission.
 

--- a/scripts/test_validate_zsh_standard_policy.py
+++ b/scripts/test_validate_zsh_standard_policy.py
@@ -1990,7 +1990,7 @@ class ZshStandardPolicyValidatorTests(unittest.TestCase):
 
         self.assertEqual(
             digest,
-            "1a958a39d678afef3c4a42fa8163a131d8799e7adbc457403147c31eeff0ec19",
+            "905120edbdec5284d5da310be9552fd861028d0dbb541894e7333dec9eec39f3",
         )
 
     def test_rejects_list_and_nested_container_rule_headings(self) -> None:


### PR DESCRIPTION
## Summary

- Document the manual issue-to-PR link needed when repository policy requires a non-default PR base.
- Include the Zsh-safe GraphQL form and two-sided relationship verification.
- Refresh the stale parser snapshot digest after the organization README input changed.
- Related context: https://github.com/z-shell/zi/issues/465 and https://github.com/z-shell/zi/pull/466

## Verification

- `python3 -m unittest scripts/test_validate_zsh_standard_policy.py` (99 tests)
- `python3 scripts/validate-zsh-standard-policy.py`
- `python3 scripts/validate-agent-policy.py`
- `python3 -m unittest scripts/test_validate_agent_policy.py` (84 tests)
- `python3 scripts/test-agent-instructions.py` (90 tests)
- GitHub issues skill validator
- `trunk check --no-fix --no-progress .github/skills/github-issues/SKILL.md scripts/test_validate_zsh_standard_policy.py`
- `git diff --check origin/main...HEAD`

## Instruction impact

- The existing `github-issues` skill remains the canonical owner.
- Discovery manifests and mandatory delivery paths are unchanged.

## Agent handoff

No handoff needed.
