### PR TITLE
feat(release): allow approval-gated Zi automation

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -1,11 +1,12 @@
 ---
 name: Release Prepare
 
-# Prepares — but never publishes — a release for class-2 repositories
-# (decisions/0007-release-publication-flow.md). On every push to the default
-# branch it computes the next semantic version from Conventional Commits since
-# the last tag, drafts a changelog with GitHub Models (falling back to a
-# grouped commit list), and opens or updates a single release-proposal issue.
+# Prepares, but never publishes, a release for class-2 repositories and the
+# named Zi exception (decisions/0007-release-publication-flow.md). On every
+# push to the default branch it computes the next semantic version from
+# Conventional Commits since the last tag, drafts a changelog with GitHub
+# Models (falling back to a grouped commit list), and opens or updates a single
+# release-proposal issue.
 # The maintainer-pushed annotated tag remains the only publication act.
 
 on:
@@ -35,6 +36,11 @@ on:
         required: false
         type: string
         default: "release-proposal"
+      signed_tag:
+        description: Emit a signed annotated tag command in the proposal.
+        required: false
+        type: boolean
+        default: false
     outputs:
       version:
         description: >
@@ -235,11 +241,18 @@ jobs:
           PREVIOUS_TAG: ${{ steps.semver.outputs.previous-tag }}
           TAG_PREFIX: ${{ inputs.tag-prefix || 'v' }}
           PROPOSAL_LABEL: ${{ inputs.proposal-label || 'release-proposal' }}
+          SIGNED_TAG: ${{ inputs.signed_tag }}
           AI_RESPONSE_FILE: ${{ steps.ai.outputs.response-file }}
         run: |
           set -euo pipefail
           dir="${RUNNER_TEMP}/release-prepare"
           tag="${TAG_PREFIX}${VERSION}"
+          tag_flag="-a"
+          tag_kind="annotated"
+          if [ "$SIGNED_TAG" = "true" ]; then
+            tag_flag="-s"
+            tag_kind="signed annotated"
+          fi
 
           changelog="${dir}/fallback.md"
           if [ -n "${AI_RESPONSE_FILE}" ] && [ -s "${AI_RESPONSE_FILE}" ]; then
@@ -265,12 +278,12 @@ jobs:
             echo
             echo "## To publish"
             echo
-            echo "Per [ADR 0007](https://github.com/z-shell/.github/blob/main/decisions/0007-release-publication-flow.md) the annotated tag is the publication boundary — review, adjust the version if needed, then:"
+            echo "Per [ADR 0007](https://github.com/z-shell/.github/blob/main/decisions/0007-release-publication-flow.md) the ${tag_kind} tag is the publication boundary. Review and adjust the version if needed, then:"
             echo
             echo '```sh'
             echo "git switch ${GITHUB_REF_NAME} && git pull --ff-only"
             echo "# bump any in-repo version metadata first, if this repository has it"
-            echo "git tag -a ${tag} -m ${tag}"
+            echo "git tag ${tag_flag} ${tag} -m ${tag}"
             echo "git push origin ${tag}"
             echo '```'
             echo

--- a/decisions/0007-release-publication-flow.md
+++ b/decisions/0007-release-publication-flow.md
@@ -37,7 +37,8 @@ formalizes.
    only from those tags.
 3. **Git-consumed source** (`zi`, most plugins/annexes): Conventional Commits for
    clean history; CI is validation-only; **no release automation** unless the
-   repo later gains a separate packaged artifact.
+   repo later gains a separate packaged artifact or this ADR names an explicit
+   milestone-release exception.
 4. **Meta/infrastructure** (`.github`): Conventional Commits; no release
    automation.
 
@@ -70,9 +71,28 @@ Per-repo application:
 - **packaged `zsh`** — deferred: confirm what it publishes (npm package vs.
   metadata) before wiring a release, since the artifact determines the steps.
   (`zsh#8`.)
-- **`zi`** — class 3, git-consumed; **no release automation added**. Its
-  `next` to stable `main` promotion (`zi#346`) is governed by ADR-0019, while
-  this ADR adds no tag-driven release workflow to `zi`.
+- **`zi`**: class 3, git-consumed, with approval-gated milestone automation. Its
+  `next` to stable `main` promotion is governed by ADR-0019. The named
+  milestone-release exception below applies without changing `main` as the
+  stable Git-consumption boundary.
+
+### Zi milestone-release exception
+
+Zi may automate release preparation and publication under this contract:
+
+- a successful promotion to `main` may compute the next semantic version and
+  draft release notes, but preparation never creates or pushes a tag;
+- a maintainer authorizes publication by pushing an annotated, signed
+  `vX.Y.Z` tag to the exact verified `main` commit;
+- the tag-triggered workflow verifies the signature, exact target, and
+  successful required workflows on that commit before publishing the GitHub
+  release; and
+- Zi does not adopt `release-please` or a stored version file. Runtime version
+  reporting continues to derive from Git metadata.
+
+The signed tag is the human approval boundary. Automation after that boundary
+may be idempotent, but it must fail closed when the tag or validation evidence
+does not match the contract.
 
 ## Consequences
 
@@ -81,8 +101,9 @@ Per-repo application:
 - `zsh-lint` gains a notes-only tag-driven `release.yml`.
 - `release-please` is not adopted org-wide; it remains available to revisit per
   repo if a maintainer wants automated changelog/version PRs.
-- Class-3 repos (incl. `zi`) keep validation-only CI; tagging there is a manual,
-  policy-governed act, not automation.
+- Class-3 repositories remain validation-only by default. Zi is the named
+  exception: release preparation and publication may be automated, while tag
+  creation remains a manual, policy-governed act.
 
 ## Alternatives considered
 
@@ -92,6 +113,9 @@ Per-repo application:
   decision. Can be piloted per repo later without contradicting this ADR.
 - **One release model for all repos.** Rejected: continuously-deployed and
   git-consumed repos do not benefit from tag-driven release artifacts.
+- **Create a Zi tag on every promotion.** Rejected: not every promotion needs a
+  milestone release, and an automatically created tag would remove the exact
+  human publication approval boundary.
 - **Defer the ADR, keep guidance informal.** Rejected: the runbook explicitly
   waited on this decision; leaving it open invites drift.
 
@@ -101,6 +125,9 @@ Per-repo application:
 - `z-shell/zunit` `.github/workflows/release.yml` — reference tag-driven flow.
 - `decisions/0003-conventional-commits.md` — history format this builds on.
 - Tracker: `zsh-lint#21`, `zsh#8`, `zi#346`.
+- [Issue #583](https://github.com/z-shell/.github/issues/583) and
+  [zi#468](https://github.com/z-shell/zi/issues/468): approved Zi
+  milestone-release automation.
 - [Issue #497](https://github.com/z-shell/.github/issues/497) and
   [z-shell/zpmod#70](https://github.com/z-shell/zpmod/issues/70): accepted
   `zpmod` classification and owning repository remediation.

--- a/decisions/0009-testing-ci-strategy.md
+++ b/decisions/0009-testing-ci-strategy.md
@@ -72,9 +72,12 @@ rollout status per repository is tracked in issue #454, not restated here.
    part of the security surface governed by
    `decisions/0010-security-incident-response.md`.
 3. **Git-consumed source** (`zi`, most plugins/annexes) — **validation-only**: the
-   baseline checks above, plus ZUnit where the plugin ships tests. No release
-   automation and no coverage gate; these repos are consumed from source and the
-   bar is "does not break on load."
+   baseline checks above, plus ZUnit where the plugin ships tests. No coverage
+   gate; these repos are consumed from source and the bar is "does not break on
+   load." Release automation is absent by default. ADR-0007's named Zi
+   milestone exception additionally requires a signed tag targeting the exact
+   current `main` commit and successful required `main` workflows before the
+   GitHub release is published.
 4. **Meta/infrastructure** (`.github`) — baseline plus workflow/markdown linting.
 
 ### Coverage
@@ -100,9 +103,8 @@ that a ruleset enforces it.
 - A reviewer can determine the target CI bar from the repository's class
   instead of inferring policy from each workflow.
 - New repositories have an explicit target CI scope for their class.
-- "Validation-only for git-consumed repositories" becomes an explicit rule,
-  discouraging release machinery in class-3 repositories (consistent with
-  ADR-0007).
+- "Validation-only for git-consumed repositories" remains the default rule,
+  while ADR-0007 owns Zi's narrow approval-gated milestone exception.
 - The testing instruction distinguishes the organization target from verified
   repository-local enforcement so agents do not infer live gates from policy
   prose or workflow-file presence.

--- a/runbooks/release.md
+++ b/runbooks/release.md
@@ -56,6 +56,9 @@ Policy:
 - use Conventional Commits for clean history and cross-repo reasoning
 - keep CI focused on validation
 - do **not** add release automation unless the repository later gains a separate packaged artifact or a clear tag-driven release workflow with maintainer buy-in
+- for Zi only, follow ADR-0007's named milestone exception: prepare
+  automatically, authorize with a maintainer-pushed signed tag, then publish
+  only after exact-ref validation
 
 ### 4. Meta and infrastructure repositories
 
@@ -99,11 +102,12 @@ ancestry-preserving promotion needs no reconciliation. A `zi` hotfix merged
 directly to `main` is synchronized into `next` through the reviewed merge
 procedure in the branch-protection runbook.
 
-## Release preparation automation (class 2)
+## Release preparation automation (class 2 and Zi)
 
 The reusable workflow
 [`release-prepare.yml`](../.github/workflows/release-prepare.yml) automates the
 _preparation_ half of the class-2 flow without moving the publication boundary.
+Zi may also call it under ADR-0007's named milestone exception.
 On every push to the default branch it:
 
 1. computes the next semantic version from Conventional Commits since the last
@@ -116,7 +120,11 @@ On every push to the default branch it:
 
 The maintainer-pushed annotated tag remains the only publication act, and the
 repository's tag-driven `release.yml` (zunit pattern) still does the
-publishing, so ADR 0007 is unchanged.
+publishing, so the class-2 publication boundary is unchanged.
+
+For Zi, set `signed_tag: true`. Its maintainer-pushed annotated, signed tag is
+the publication authorization, and the tag workflow must validate the exact
+tag target and required `main` workflows before creating the release.
 
 Caller snippet for a class-2 repository:
 
@@ -142,13 +150,23 @@ jobs:
     uses: z-shell/.github/.github/workflows/release-prepare.yml@main
 ```
 
+Zi adds the signed-tag input:
+
+```yaml
+jobs:
+  propose:
+    uses: z-shell/.github/.github/workflows/release-prepare.yml@main
+    with:
+      signed_tag: true
+```
+
 Notes:
 
 - Callers own `concurrency`; the reusable workflow does not set it.
 - `models: read` enables the GitHub Models changelog draft; without it the
   workflow still opens the proposal with the fallback commit list.
-- Do **not** add this to class-1, class-3, or class-4 repositories — they have
-  no tag boundary to prepare for.
+- Do **not** add this to class-1, class-4, or another class-3 repository. Zi is
+  the only named class-3 exception.
 
 ## Release-automation decision checklist
 


### PR DESCRIPTION
## Summary

- name Zi as the only class-3 milestone-release automation exception
- keep maintainer-pushed signed tags as the publication authorization boundary
- let the reusable preparation workflow emit the signed-tag command for Zi
- document the fail-closed checks required before a Zi GitHub release is published

## Instruction impact review

1. **Classification:** Shared release policy and reusable workflow behavior. Enforcement for the eventual Zi publication path remains in the Zi repository.
2. **Contexts:** The organization release policy, testing policy, reusable release preparation caller, and Zi maintainers consume this change. No runtime adapter changes are needed.
3. **Canonical owner:** ADR-0007 remains the release-model owner, ADR-0009 owns the related validation requirement, and `runbooks/release.md` owns the operational procedure.
4. **Duplication or contradiction:** Existing class-3 language was updated in both ADRs and the runbook. Zi is explicitly narrow, so the default prohibition remains consistent for every other class-3 repository.
5. **Manifest routes:** No route changes are needed. All affected files are already routed as release policy, testing policy, reusable workflow, or runbook content.
6. **Runtime delivery:** Yes. Mandatory rules live in canonical repository files and the workflow itself, without relying on an optional hook or skill.
7. **Generated output and size limits:** No generated instruction source changed. Public policy validation and all 84 agent-policy tests pass.

## Validation

- `python3 scripts/decision-records.py --check`
- `python3 -m unittest scripts/test_decision_records.py -v` (17 passed)
- `python3 scripts/validate-agent-policy.py`
- `python3 -m unittest scripts/test_validate_agent_policy.py -v` (84 passed)
- `actionlint .github/workflows/release-prepare.yml`
- Ruby YAML parse with aliases enabled
- safe Trunk check on all four changed files
- `git diff --check`

Closes #583
Unblocks z-shell/zi#468
