### PR TITLE
chore(ci): explain the frozen golden in its own failure message

### DIFF
--- a/scripts/test_validate_zsh_standard_policy.py
+++ b/scripts/test_validate_zsh_standard_policy.py
@@ -1991,6 +1991,14 @@ class ZshStandardPolicyValidatorTests(unittest.TestCase):
         self.assertEqual(
             digest,
             "607f548eb63159678258e5caec4ae63ced8592906d2cb542f57b9ac1239a945b",
+            msg=(
+                "The frozen golden covers the parsed output of every path in "
+                f"{paths}. Editing any of them changes this digest, which is "
+                "the test working as intended. Review the diff to confirm the "
+                "content change is what you meant, then replace the expected "
+                "digest above with the one reported as actual and commit both "
+                "together. See z-shell/.github#588."
+            ),
         )
 
     def test_rejects_list_and_nested_container_rule_headings(self) -> None:


### PR DESCRIPTION
Learning capture from #586, which appended one section to `PATTERNS.md` and
failed `Validate Agent Instructions` with nothing but two bare SHA-256 strings.

`test_repair_2_consumer_parser_outputs_match_frozen_golden` hashes the parsed
output of seven consumer surfaces, `PATTERNS.md` and `.github/README.md` among
them. Editing any of them changes the digest, which is the test working
correctly. Nothing recorded that, though: `grep -ri golden` over `AGENTS.md`,
`runbooks/`, `decisions/`, and `.github/instructions/` returns nothing, and the
test file has been amended nine times. #582 hit the same wall on a skill edit.

This attaches the seven paths and the regeneration procedure to the assertion's
`msg=`, so both appear in the failure output. One argument covers all seven
surfaces, where a per-file comment would cover one each and drift as the list
changes.

Verified by appending a line to `PATTERNS.md` and re-running the test. The
message renders with every path enumerated, and `PATTERNS.md` was restored, so
this branch changes one file. The full suite of 99 tests passes, as do
`validate-agent-policy.py` and the Python linters.

Closes #588
