### PR TITLE
fix(ci): allow agent-generated and slugged branch names

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -35,9 +35,13 @@ on:
         type: string
       branch-pattern:
         description: >
-          grep -E pattern a PR head branch must match. dependabot/* and
-          renovate/* are always allowed. next is allowed only for z-shell/zi.
-          Falls back to ^(feature|bug|hotfix)-[1-9][0-9]*$ in the job step.
+          grep -E pattern a PR head branch must match. Agent- and
+          bot-generated prefixes (dependabot/, renovate/, copilot/, codex/) are
+          always allowed, because the pull-request author does not choose those
+          names. next is allowed only for z-shell/zi. Falls back to
+          ^(feature|bug|hotfix)-[1-9][0-9]*(-[a-z0-9]+)*$ in the job step, which
+          keeps the issue id mandatory and permits a descriptive slug after it
+          (decisions/0019).
         required: false
         type: string
 
@@ -131,9 +135,9 @@ jobs:
 
           # As above: an empty pattern would match every branch name and turn
           # this job into a silent pass.
-          : "${BRANCH_PATTERN:=^(feature|bug|hotfix)-[1-9][0-9]*$}"
+          : "${BRANCH_PATTERN:=^(feature|bug|hotfix)-[1-9][0-9]*(-[a-z0-9]+)*$}"
 
-          if echo "$BRANCH" | grep -qE '^(dependabot|renovate)/' || \
+          if echo "$BRANCH" | grep -qE '^(dependabot|renovate|copilot|codex)/' || \
              { [ "$REPOSITORY" = "z-shell/zi" ] && [ "$BRANCH" = "next" ]; }; then
             echo "✅ OK"
             exit 0


### PR DESCRIPTION
`Validate Branch Name` became a blocking required status check here after #586.
Across the last 60 pull requests into this repository, 14 head branches match
the pattern and 46 do not. Two groups inside that 46 are not a naming
discipline problem, and this fixes both.

1. **Agent-generated prefixes.** `copilot/` and `codex/` join `dependabot/` and
   `renovate/` in the always-allowed list. A coding agent picks those names, so
   rejecting them penalises something the pull-request author never chose.
   `app/copilot-swe-agent` produced `copilot/docs-adr-classify-zpmod`,
   `copilot/investigate-github-pages-ci`, and `copilot/fix-metrics-job-failure`.
2. **A descriptive slug after the issue id.** The pattern becomes
   `^(feature|bug|hotfix)-[1-9][0-9]*(-[a-z0-9]+)*$`. The trailing anchor was
   rejecting `feature-478-repo-settings-audit`,
   `feature-505-zsh-lint-reference-corpus`,
   `feature-509-generator-verifier-relocation`, and
   `feature-513-promotion-trigger-policy`, all of which carry the id.

The issue id stays mandatory for author-chosen branches, so
`decisions/0019-trunk-on-main-default.md` is unchanged in substance; it writes
the form as `feature-<id>` and says nothing that forbids a suffix.

## Deliberately not included

Shapes carrying no issue id at all, `code/`, `fix/`, `feat/`, `docs/`, `ci/`,
`chore/`, and `ss-o-*`, account for roughly 36 of the 46. Allowing them would
reverse the issue-linked branch naming the ADR decided and that AGENTS.md
cites as enforced. If that is wanted it should be an ADR amendment argued on
its merits, not a widened regex. This means about 36 of the last 60 branch
names would still fail, so the naming habit does change.

## Verification

A table over 18 branch names, covering both new allowances, the existing bot
prefixes, `next`, and the shapes that must keep failing (`code/*`, `fix/*`,
`ss-o-*`, `feature-0`, `feature-`, `feature-505-`, `feature-505-Bad-Caps`,
`bugfix-12`). All 18 classify as intended. `actionlint` and `trunk check` are
clean.

No persistent test is added. A test that restated the pattern would drift from
the workflow, and one that extracted it from the YAML needs its own script and
workflow wiring. Worth doing as follow-up, given this job already shipped one
silent-pass defect (#575), but out of scope here.

Closes #590
