### PR TITLE
fix(ci): stop the trailer guard failing open on large messages

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -80,7 +80,12 @@ jobs:
           checked=0
 
           while IFS= read -r sha; do
-            if git show -s --format='%B' "$sha" | grep -qiE "$DISALLOWED_TRAILER_PATTERN"; then
+            # grep -c, not grep -q. Under pipefail, grep -q exits on its first
+            # match while git is still writing, git takes SIGPIPE and returns
+            # 141, and the pipeline result turns a real match into a miss for
+            # any message larger than the pipe buffer. grep -c reads to the end,
+            # so the writer always finishes (z-shell/.github#587).
+            if [ "$(git show -s --format='%B' "$sha" | grep -ciE "$DISALLOWED_TRAILER_PATTERN")" -gt 0 ]; then
               echo "::error::Bot/agent Co-authored-by trailer found (${sha:0:7}): remove before merging. A human co-author is fine; only bot/AI-agent identities are banned (AGENTS.md). A squash merge without an explicit --subject/--body can also reintroduce one — see runbooks/branch-protection.md."
               errors=$((errors + 1))
             fi


### PR DESCRIPTION
Fixes the fail-open reported in #587.

`Validate Commits` matched the disallowed trailer as a pipeline under
`set -o pipefail`:

```sh
git show -s --format='%B' "$sha" | grep -qiE "$DISALLOWED_TRAILER_PATTERN"
```

`grep -q` exits on its first match. For a commit message larger than the pipe
buffer, `git` is still writing at that moment, takes `SIGPIPE`, and returns
`141`. `pipefail` promotes that to the pipeline result, the `if` sees failure,
and a banned trailer that was actually present is reported as absent.

## The fix

`grep -c` with a numeric test. `grep -c` reads to the end of its input, so the
writer always finishes and no `SIGPIPE` arises.

`grep -c` was chosen over a `[[ $message =~ $pattern ]]` rewrite deliberately.
Both stop the fail-open, but `[[ =~ ]]` swaps grep's ERE engine for bash's and
needs `shopt -s nocasematch` to keep the `-i` behaviour. The pattern contains
`[[:space:]]` and `\[bot\]`, and a silently different match here is worse than
the bug being fixed. `grep -c` keeps the existing engine and flags unchanged.

## Verification

Four real commits, each evaluated under both constructs:

| Commit message                    | Old (`grep -q`) | New (`grep -c`) |
| --------------------------------- | --------------- | --------------- |
| Small, bot trailer                | FLAGGED         | FLAGGED         |
| **3 MB, bot trailer**             | **clean**       | **FLAGGED**     |
| 3 MB, human `Co-authored-by`      | clean           | clean           |
| 3 MB, no trailer                  | clean           | clean           |

The second row is the defect and the only behaviour that changes. A human
co-author is still allowed, and a large clean message still passes, so nothing
starts failing that should not.

`actionlint` and `trunk check` are clean.

## Not included

`z-shell/zi` carries the same construct and needs the same fix; tracked
separately so each repository's change is reviewable on its own.

#592 proposes a test harness for these patterns. It lands after this fix
rather than with it, so the harness can be shown to catch the pre-fix construct
rather than merely passing against the fixed one.

Closes #587
