### PR TITLE
docs(zsh-standard): require a removal's test to be able to fail

### DIFF
--- a/.github/instructions/zsh-scripting.instructions.md
+++ b/.github/instructions/zsh-scripting.instructions.md
@@ -315,6 +315,31 @@ and remember that a system `zshenv` may still execute.
 Mark intentionally invalid, legacy, or lint-negative fixtures in repository
 metadata instead of excluding an entire test directory.
 
+### `zsh/test/cover-removed-behavior`
+
+- Level: `required`
+- Profiles: `test-fixture`
+- Minimum Zsh: `null`
+- Basis: `organization-policy`
+- Evidence: `manual-index`
+- Enforcement: `human-review`
+
+When a change removes code on the grounds that it is unnecessary, a test
+offered as evidence for that removal must exercise the behaviour the removed
+code provided. Observe it failing with the code removed and passing with it
+present. A test that passes in both states supports nothing and must not be
+cited as though it does.
+
+Run the candidate test against the unmodified source before removing anything.
+If it passes there, it is not evidence, and either the test or the premise of
+the removal is wrong.
+
+This applies with particular force where a line looks inert: a declaration that
+appears redundant, an assignment whose value seems unused, a mutation that
+resembles a leak. Such a line is exactly the kind that gets removed on
+inspection, and exactly the kind whose loss a nearby test will not notice
+because the test covers the path the line does not serve.
+
 ### `zsh/test/match-production-profile`
 
 - Level: `required`

--- a/lib/zsh-standard-policy.json
+++ b/lib/zsh-standard-policy.json
@@ -311,6 +311,15 @@
       "enforcement": ["classifier"]
     },
     {
+      "id": "zsh/test/cover-removed-behavior",
+      "level": "required",
+      "profiles": ["test-fixture"],
+      "minimum_zsh": null,
+      "basis": "organization-policy",
+      "evidence": ["manual-index"],
+      "enforcement": ["human-review"]
+    },
+    {
       "id": "zsh/test/match-production-profile",
       "level": "required",
       "profiles": ["test-fixture"],

--- a/scripts/test_validate_zsh_standard_policy.py
+++ b/scripts/test_validate_zsh_standard_policy.py
@@ -1979,7 +1979,7 @@ class ZshStandardPolicyValidatorTests(unittest.TestCase):
             },
             "parsed_rules": validator._markdown_rules(instruction),
         }
-        self.assertEqual(len(snapshot["rule_blocks"]), 65)
+        self.assertEqual(len(snapshot["rule_blocks"]), 66)
         digest = hashlib.sha256(
             json.dumps(
                 snapshot,
@@ -1991,7 +1991,7 @@ class ZshStandardPolicyValidatorTests(unittest.TestCase):
 
         self.assertEqual(
             digest,
-            "d841ec864632352bc399bb035780e6805200425a4f14b0b700d3e7a9e8f7c59e",
+            "c2faea55b03018e947b6e1b5fef023c4d50a9474cfc9f4c4f372f68cabf6ba58",
             msg=(
                 "The frozen golden covers the parsed output of every path in "
                 f"{paths}. Editing any of them changes this digest, which is "

--- a/scripts/validate-zsh-standard-policy.py
+++ b/scripts/validate-zsh-standard-policy.py
@@ -144,6 +144,7 @@ NORMATIVE_RULE_IDS = (
     "zsh/completion/preserve-trust-boundaries",
     "zsh/test/isolate-environment",
     "zsh/test/declare-negative-fixtures",
+    "zsh/test/cover-removed-behavior",
     "zsh/test/match-production-profile",
     "zsh/options/canonical-spelling",
     "zsh/options/declare-correctness-state",


### PR DESCRIPTION
Adds `zsh/test/cover-removed-behavior`. Documentation and policy only.

## Why

[zi#488](https://github.com/z-shell/zi/issues/488) was not caused by a missing test. It was caused by a test that could not fail.

[zi#477](https://github.com/z-shell/zi/pull/477) removed a line as dead and added `tests/plugin-autoload-fpath-scope.zsh` as evidence the removal was safe. Its commit message said so outright:

> It passes before and after, which is the point.

That is the defect. The test asserted `autoload +X` only for functions in the plug-in's *own* directories, which resolve from `$PLUGIN_DIR` with or without the removed line. The behaviour the line actually provided, carrying the caller's `$fpath` so a *foreign* function could resolve, was never exercised. The test passed on both sides because it was blind to the only thing at issue, and `Aloxaf/fzf-tab` broke completely.

A test whose result is invariant to the change it accompanies is evidence of nothing, and it is worse than no test: it reads as diligence and closes down review.

## It recurred immediately

While fixing #488 I inspected the neighbouring `-w` branch of the same function, judged its `fpath+=( $PLUGIN_DIR )` an unlocalized leak from its shape alone, and wrote the "fix". It broke `-w` completely: `autoload -w <digest>` declares functions that resolve lazily at first call, so that append has to outlive the call. The full suite stayed green while `-w` was broken end to end, because nothing exercised it either. Corrected in [zi#493](https://github.com/z-shell/zi/pull/493).

Two instances, one function, one release cycle. Both times a line was judged inert on sight, and both times the test set was structurally incapable of disagreeing.

## Duplicate search

Per the candidate quality gate in `runbooks/learning-capture.md`:

| Existing rule | Governs |
| :--- | :--- |
| `zsh/review/report-without-rewrite` | read-only work, not removals |
| `zsh/change/conform-touched-code` | scope of cleanup, not its evidence |
| `zsh/test/isolate-environment` | how a test is built |
| `zsh/test/declare-negative-fixtures` | how a test is built |
| `zsh/test/match-production-profile` | how a test is built |

Nothing requires that a test cited for a removal be capable of failing without the removed code.

## The rule

Scoped to `test-fixture`, matching the other rules in that section: the obligation lands on the test artifact, not on the profile of the code being removed. My first draft declared all five profiles, which the validator's `startup-file` membership check correctly rejected.

The check itself is cheap: run the candidate test against the unmodified source. If it passes there, it is not evidence.

## Verification

```text
python3 scripts/validate-zsh-standard-policy.py      -> passed
python3 scripts/test_validate_zsh_standard_policy.py -> Ran 99 tests, OK
```

Frozen consumer-parser golden: block count 65 to 66, digest replaced. `startup-file` membership unchanged.

Closes #604
